### PR TITLE
feat: add CSS scroll-driven animation table of contents

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,124 @@
+---
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface Props {
+  headings: Heading[];
+}
+
+const { headings } = Astro.props;
+
+const timelineNames = headings.map(h => `--toc-${h.slug}`).join(', ');
+
+const dynamicStyles = `
+  .toc-scope {
+    timeline-scope: ${timelineNames};
+  }
+
+  @supports (animation-timeline: view()) {
+    ${headings.map(h => `[id="${h.slug}"] {
+      view-timeline-name: --toc-${h.slug};
+      view-timeline-axis: block;
+    }`).join('\n    ')}
+
+    ${headings.map(h => `a[data-toc-slug="${h.slug}"] {
+      animation: toc-active linear both;
+      animation-timeline: --toc-${h.slug};
+      animation-range: cover 0% cover 100%;
+    }`).join('\n    ')}
+  }
+`;
+---
+
+<nav class="toc hidden xl:block" aria-label="Table of contents">
+  <div class="toc-sticky">
+    <p class="toc-heading">Contents</p>
+    <ul class="toc-list">
+      {headings.map((heading) => (
+        <li class={heading.depth === 3 ? 'toc-indent' : ''}>
+          <a
+            href={`#${heading.slug}`}
+            class="toc-link"
+            data-toc-slug={heading.slug}
+          >
+            {heading.text}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </div>
+</nav>
+
+<style set:html={dynamicStyles}></style>
+
+<style>
+  .toc {
+    position: absolute;
+    right: 2rem;
+    top: 0;
+    width: 14rem;
+    height: 100%;
+    padding-top: 2rem;
+  }
+
+  .toc-sticky {
+    position: sticky;
+    top: 6rem;
+  }
+
+  .toc-heading {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--toc-inactive-color);
+    margin-bottom: 1rem;
+  }
+
+  .toc-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .toc-indent {
+    padding-left: 1rem;
+  }
+
+  .toc-link {
+    display: block;
+    padding: 0.25rem 0 0.25rem 0.75rem;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    color: var(--toc-inactive-color);
+    text-decoration: none;
+    border-left: 2px solid transparent;
+    transition: color 0.2s ease;
+    background-image: none !important;
+    background-size: 0 !important;
+    font-weight: 400 !important;
+  }
+
+  .toc-link:hover {
+    color: var(--toc-active-color);
+    background-image: none !important;
+    background-size: 0 !important;
+  }
+
+  @keyframes toc-active {
+    0% {
+      color: var(--toc-active-color);
+      border-left-color: var(--toc-active-border);
+    }
+    100% {
+      color: var(--toc-inactive-color);
+      border-left-color: transparent;
+    }
+  }
+</style>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -5,6 +5,7 @@ import Footer from '../components/Footer.astro';
 import ImageLightbox from '../components/ImageLightbox.astro';
 import Breadcrumb from '../components/Breadcrumb.astro';
 import ReadingTime from '../components/ReadingTime.astro';
+import TableOfContents from '../components/TableOfContents.astro';
 import similarities from '../assets/similarities.json';
 import { ViewTransitions } from 'astro:transitions';
 
@@ -18,7 +19,10 @@ const {
   identifier,
   slug,
   rawBody,
+  headings = [],
 } = Astro.props;
+
+const filteredHeadings = headings.filter((h: { depth: number }) => h.depth === 2 || h.depth === 3);
 
 // Generate breadcrumb items
 const breadcrumbItems = [
@@ -48,16 +52,16 @@ const relatedPosts =
 	<body class="bg-white dark:bg-slate-900">
 		<Header />
 		<main class="bg-white relative shadow z-10 dark:bg-slate-900 dark:text-slate-200">
-			<article>
+			<article class="toc-scope">
 				<header class="longform grid aspect-[3/2] bg-slate-900">
 					{cloudinaryThumb && (
 						<>
-							<img 
-								alt={thumbAlt} 
-								class="block col-start-1 row-start-1 w-full h-full object-cover animate-image-fade-in z-0 no-lightbox" 
+							<img
+								alt={thumbAlt}
+								class="block col-start-1 row-start-1 w-full h-full object-cover animate-image-fade-in z-0 no-lightbox"
 								loading="eager"
-								src={`https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_375,q_auto/v1673896360/${cloudinaryThumb}`} 
-								srcset={`https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_750,q_auto/v1673896360/${cloudinaryThumb} 375w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_1000,q_auto/v1673896360/${cloudinaryThumb} 500w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_1344,q_auto/v1673896360/${cloudinaryThumb} 672w,`} 
+								src={`https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_375,q_auto/v1673896360/${cloudinaryThumb}`}
+								srcset={`https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_750,q_auto/v1673896360/${cloudinaryThumb} 375w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_1000,q_auto/v1673896360/${cloudinaryThumb} 500w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_1344,q_auto/v1673896360/${cloudinaryThumb} 672w,`}
 							/>
 							<div class="col-start-1 row-start-1 bg-black w-full h-full animate-fade-overlay z-10"></div>
 						</>
@@ -67,7 +71,12 @@ const relatedPosts =
 					</h1>
 				</header>
 
-				<div class="longform max-w-2xl mx-auto pb-16 pt-8 px-8 lg:px-0 blogpost">
+				<div class="relative">
+					{filteredHeadings.length >= 2 && (
+						<TableOfContents headings={filteredHeadings} />
+					)}
+
+			<div class="longform max-w-2xl mx-auto pb-16 pt-8 px-8 lg:px-0 blogpost">
 					{rawBody && (
 						<div class="mb-6">
 							<ReadingTime content={rawBody} />
@@ -105,6 +114,7 @@ const relatedPosts =
 							<a href="/posts/front-end-dev/strapi-series-part-11-header-and-footer-links/">Part 11: Header and Footer Links</a>
 						</nav>
 					)}
+				</div>
 				</div>
 			</article>
 			

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -23,9 +23,9 @@ export async function getStaticPaths() {
 type Props = CollectionEntry<'posts'> & { identifier: string };
 
 const post = Astro.props;
-const { Content } = await post.render();
+const { Content, headings } = await post.render();
 ---
 
-<BlogPost {...post.data} identifier={post.identifier} rawBody={post.body}>
+<BlogPost {...post.data} identifier={post.identifier} rawBody={post.body} headings={headings}>
 	<Content />
 </BlogPost>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+/* TOC Colors */
+
+:root {
+  --toc-active-color: #b91c1c;
+  --toc-inactive-color: #6b7280;
+  --toc-active-border: #b91c1c;
+}
+
+.dark {
+  --toc-active-color: #fca5a5;
+  --toc-inactive-color: #9ca3af;
+  --toc-active-border: #fca5a5;
+}
+
 /* Scroll */
 
 


### PR DESCRIPTION
## Summary

Added a sticky sidebar table of contents to blog posts using CSS `animation-timeline: view()` to highlight the currently visible section as users scroll. The TOC renders at build time from Astro's heading data and gracefully degrades to a clickable navigation list in unsupporting browsers (Safari/Firefox).

## Changes

- New `TableOfContents.astro` component with dynamic per-heading CSS timelines
- Updated `BlogPost.astro` layout to conditionally render TOC (2+ headings minimum)
- Extract and pass heading data through the rendering pipeline
- Added TOC color custom properties supporting light/dark modes

## Browser Support

Works in Chrome/Edge 116+. Degrades gracefully in Safari/Firefox (static nav with anchor links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)