### PR TITLE
refactor: redesign listing pages with cohesive grid language

### DIFF
--- a/src/pages/blips/index.astro
+++ b/src/pages/blips/index.astro
@@ -2,43 +2,74 @@
 import BaseHead from '../../components/BaseHead.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
+import { SITE_TITLE } from '../../consts';
 import { getCollection } from 'astro:content';
+import { ViewTransitions } from 'astro:transitions';
 
 const blips = (await getCollection('blips')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
 ---
-
 <!doctype html>
 <html lang="en">
 	<head>
 		<BaseHead title="Blips | Dan Denney" description="Shorter than a blog post, longer than a tweet" />
+		<ViewTransitions />
 	</head>
 	<body class="bg-white dark:bg-slate-900">
-		<Header />
 		<main class="bg-white relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200">
-			<section class="pt-16 pb-24 shadow-xs sm:pb-32">
-				<div class="mx-auto max-w-7xl px-6 lg:px-8">
-					<div class="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-						<div>
-							<div class="md:sticky md:left-0 md:top-8">
-								<p class="text-lg font-semibold leading-8 tracking-tight text-slate-400 dark:text-slate-400">Quick Hits</p>
-								<h1 class="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100">Blips</h1>
-								<p class="mt-6 text-base leading-7 text-gray-600 dark:text-slate-100">Shorter than a blog post, longer than a tweet. This is where I share quick reactions or stash things I want to remember.</p>
-							</div>
-						</div>
-						<ul class="has-links grid grid-cols-1 gap-x-8 gap-y-10 text-base leading-7 text-gray-600 sm:grid-cols-2 lg:col-span-2 lg:gap-y-8 lg:grid-cols-2">
-							{blips.map((blip) => (
-								<li class="border-b border-solid border-slate-200 pb-8 dark:border-slate-600">
-									<a class="link" href={`/blips/${blip.slug}/`}>
+			<Header title={SITE_TITLE} />
+
+			<section class="pt-16 pb-24">
+				<div class="px-8">
+					<p class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+						<span class="whitespace-nowrap">[&nbsp;{blips.length} blips&nbsp;]</span>
+					</p>
+					<h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100">Blips</h1>
+					<p class="mt-4 max-w-2xl text-lg leading-8 text-gray-600 dark:text-slate-100">
+						Shorter than a blog post, longer than a tweet. Quick reactions or things I want to remember.
+					</p>
+				</div>
+
+				<div class="blips-grid mt-12 grid grid-cols-1 md:grid-cols-3 border-y border-gray-200 dark:border-slate-700">
+					{blips.map((blip, i) => {
+						const wideIndices = new Set([0, 5, 11, 18, 24, 31, 37, 44]);
+						const isWide = wideIndices.has(i);
+						const dateStr = blip.data.pubDate.toLocaleDateString('en-US', {
+							month: 'short',
+							day: 'numeric',
+							year: 'numeric',
+						});
+						return (
+							<a
+								href={`/blips/${blip.slug}/`}
+								class:list={[
+									"blips-grid-item group relative flex items-center justify-between no-underline p-6 md:p-8 bg-slate-50 dark:bg-slate-800",
+									isWide ? "md:col-span-2" : "",
+								]}
+							>
+								<div class="min-w-0 flex-1 pr-4 md:pr-6">
+									<p class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+										<span class="whitespace-nowrap">[&nbsp;{dateStr}&nbsp;]</span>
+									</p>
+									<h3 class="mt-3 text-lg font-semibold leading-snug text-red-700 transition-colors group-hover:text-red-800 dark:text-red-400 dark:group-hover:text-red-300">
 										{blip.data.title}
-									</a>
-									<p class="text-sm dark:text-slate-300">{blip.data.summary}</p>
-								</li>
-								))
-							}
-						</nav>
-					</div>
+									</h3>
+									{blip.data.summary && (
+										<p class="mt-3 text-sm leading-relaxed text-gray-500 dark:text-slate-400">
+											{blip.data.summary}
+										</p>
+									)}
+								</div>
+								<svg class="blip-radar shrink-0" width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+									<circle class="blip-ring blip-ring-3" cx="16" cy="16" r="15" stroke="currentColor" stroke-width="0.75" />
+									<circle class="blip-ring blip-ring-2" cx="16" cy="16" r="10" stroke="currentColor" stroke-width="0.75" />
+									<circle class="blip-ring blip-ring-1" cx="16" cy="16" r="5" stroke="currentColor" stroke-width="0.75" />
+									<circle class="blip-core" cx="16" cy="16" r="2.5" fill="currentColor" />
+								</svg>
+							</a>
+						);
+					})}
 				</div>
 			</section>
 		</main>

--- a/src/pages/music/index.astro
+++ b/src/pages/music/index.astro
@@ -21,84 +21,69 @@ export const prerender = true;
     <main
       class="bg-white relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200"
     >
-      <section class="relative isolate overflow-hidden pb-16">
-        <Header title={SITE_TITLE} />
+      <Header title={SITE_TITLE} />
 
-        <div class="mx-auto max-w-7xl pt-16 px-6 lg:px-8">
-          <div class="mx-auto max-w-2xl lg:mx-0">
-            <p
-              class="text-lg font-semibold leading-8 tracking-tight text-slate-400"
-            >
-              What I'm Listening To
-            </p>
-            <h1
-              class="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100"
-            >
-              Seasons of Dan
-            </h1>
-            <p class="mt-4 text-xl leading-8 text-gray-700 text-pretty dark:text-slate-100">
-              A look at what my listening actually looks like over time. Each
-              section shows my top tracks and artists from different time
-              periods.
-            </p>
+      <section class="pt-16">
+        <div class="px-8">
+          <p class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+            <span class="whitespace-nowrap">[&nbsp;Spotify Listening History&nbsp;]</span>
+          </p>
+          <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100">
+            Seasons of Dan
+          </h1>
+          <p class="mt-4 max-w-2xl text-lg leading-8 text-gray-600 dark:text-slate-100">
+            What my listening actually looks like over time. Top tracks and artists from different time periods, pulled from Spotify.
+          </p>
+          <div class="has-links mt-4">
+            <a href="/music/reviews" class="text-sm font-semibold text-red-700 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300">View song reviews &rarr;</a>
           </div>
         </div>
-      </section>
 
-      <section class="pb-32">
-        <div class="mx-auto max-w-7xl px-6 lg:px-8">
-          <div
-            id="music-container"
-            class="grid grid-cols-1 gap-8 lg:grid-cols-3"
-          >
-            <!-- Skeleton loading state -->
-            {[1, 2, 3].map(() => (
-              <div class="skeleton-card relative isolate overflow-hidden p-8 rounded-2xl">
-                <div class="absolute inset-0 -z-10 bg-linear-to-br from-indigo-50/50 to-purple-50/50 dark:from-slate-800/50 dark:to-slate-900/50"></div>
-                <div class="animate-pulse">
-                  <div class="mb-6">
-                    <div class="h-8 bg-black/5 dark:bg-white/10 rounded-sm w-32 mb-2"></div>
-                    <div class="h-4 bg-black/5 dark:bg-white/10 rounded-sm w-24"></div>
-                  </div>
-                  <div class="space-y-6">
-                    <div>
-                      <div class="h-6 bg-black/5 dark:bg-white/10 rounded-sm w-28 mb-3"></div>
-                      <div class="space-y-2">
-                        {[...Array(10)].map(() => (
-                          <div class="border-b-2 border-black/5 dark:border-white/5 flex items-center gap-3 pb-4 pt-2">
-                            <div class="w-6 h-6 bg-black/5 dark:bg-white/10 rounded-sm"></div>
-                            <div class="w-10 h-10 bg-black/5 dark:bg-white/10 rounded-sm"></div>
-                            <div class="flex-1 space-y-2">
-                              <div class="h-4 bg-black/5 dark:bg-white/10 rounded-sm w-3/4"></div>
-                              <div class="h-3 bg-black/5 dark:bg-white/10 rounded-sm w-1/2"></div>
-                            </div>
-                          </div>
-                        ))}
+        <div
+          id="music-container"
+          class="music-grid mt-12 grid grid-cols-1 lg:grid-cols-3 border-y border-gray-200 dark:border-slate-700"
+        >
+          <!-- Skeleton loading state -->
+          {[
+            { title: "Right Now", subtitle: "Last 4 weeks" },
+            { title: "This Year", subtitle: "Last 6 months" },
+            { title: "All-Timer Stuff", subtitle: "Several years" },
+          ].map((range) => (
+            <div class="music-grid-item bg-slate-50 p-6 md:p-8 dark:bg-slate-800">
+              <div class="animate-pulse">
+                <p class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+                  <span class="whitespace-nowrap">[&nbsp;{range.subtitle}&nbsp;]</span>
+                </p>
+                <div class="h-7 bg-gray-200 dark:bg-slate-700 rounded w-36 mt-3"></div>
+                <div class="mt-8">
+                  <div class="h-4 bg-gray-200 dark:bg-slate-700 rounded w-24 mb-4"></div>
+                  {[...Array(5)].map(() => (
+                    <div class="flex items-center gap-3 py-3 border-b border-gray-200 dark:border-slate-700">
+                      <div class="w-5 h-4 bg-gray-200 dark:bg-slate-700 rounded"></div>
+                      <div class="w-10 h-10 bg-gray-200 dark:bg-slate-700 rounded"></div>
+                      <div class="flex-1 space-y-2">
+                        <div class="h-3.5 bg-gray-200 dark:bg-slate-700 rounded w-3/4"></div>
+                        <div class="h-3 bg-gray-200 dark:bg-slate-700 rounded w-1/2"></div>
                       </div>
                     </div>
-                    <div>
-                      <div class="h-6 bg-black/5 dark:bg-white/10 rounded-sm w-28 mb-3"></div>
-                      <div class="space-y-2">
-                        {[...Array(10)].map(() => (
-                          <div class="border-b-2 border-black/5 dark:border-white/5 flex items-center gap-3 pb-4 pt-2">
-                            <div class="w-6 h-6 bg-black/5 dark:bg-white/10 rounded-sm"></div>
-                            <div class="w-10 h-10 bg-black/5 dark:bg-white/10 rounded-full"></div>
-                            <div class="flex-1 space-y-2">
-                              <div class="h-4 bg-black/5 dark:bg-white/10 rounded-sm w-3/4"></div>
-                              <div class="h-3 bg-black/5 dark:bg-white/10 rounded-sm w-1/2"></div>
-                            </div>
-                          </div>
-                        ))}
+                  ))}
+                </div>
+                <div class="mt-8">
+                  <div class="h-4 bg-gray-200 dark:bg-slate-700 rounded w-24 mb-4"></div>
+                  {[...Array(5)].map(() => (
+                    <div class="flex items-center gap-3 py-3 border-b border-gray-200 dark:border-slate-700">
+                      <div class="w-5 h-4 bg-gray-200 dark:bg-slate-700 rounded"></div>
+                      <div class="w-10 h-10 bg-gray-200 dark:bg-slate-700 rounded-full"></div>
+                      <div class="flex-1 space-y-2">
+                        <div class="h-3.5 bg-gray-200 dark:bg-slate-700 rounded w-3/4"></div>
+                        <div class="h-3 bg-gray-200 dark:bg-slate-700 rounded w-1/2"></div>
                       </div>
                     </div>
-                  </div>
+                  ))}
                 </div>
               </div>
-            ))}
-          </div>
-        </div>
-        <div class="has-links mx-auto max-w-7xl mt-8 px-6 text-center lg:px-8">
-          <a href="/music/reviews">View music reviews</a>
+            </div>
+          ))}
         </div>
       </section>
     </main>
@@ -136,19 +121,16 @@ export const prerender = true;
           key: "short_term",
           title: "Right Now",
           subtitle: "Last 4 weeks",
-          note: "",
         },
         {
           key: "medium_term",
           title: "This Year",
           subtitle: "Last 6 months",
-          note: "",
         },
         {
           key: "long_term",
           title: "All-Timer Stuff",
           subtitle: "Several years",
-          note: "",
         },
       ] as const;
 
@@ -159,14 +141,10 @@ export const prerender = true;
         try {
           const data: Record<string, TimeRangeData> = {};
 
-          // Fetch all data in parallel
           await Promise.all(
             timeRanges.map(async ({ key }) => {
               const tracksUrl = `/api/spotify/tracks/${key}`;
               const artistsUrl = `/api/spotify/artists/${key}`;
-
-              console.log("CLIENT: Fetching tracks from:", tracksUrl);
-              console.log("CLIENT: Fetching artists from:", artistsUrl);
 
               const [tracksRes, artistsRes] = await Promise.all([
                 fetch(tracksUrl, { cache: "no-store" }),
@@ -180,107 +158,77 @@ export const prerender = true;
             }),
           );
 
-          // Render the data
           container.innerHTML = timeRanges
-            .map(({ key, title, subtitle, note }) => {
+            .map(({ key, title, subtitle }) => {
               const { tracks, artists } = data[key];
 
               return `
-              <div class="relative isolate overflow-hidden p-8 rounded-2xl">
-                <div class="absolute inset-0 -z-10 bg-linear-to-br from-indigo-50/50 to-purple-50/50 dark:from-slate-800/50 dark:to-slate-900/50"></div>
+              <div class="music-grid-item bg-slate-50 p-6 md:p-8 dark:bg-slate-800">
+                <p class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+                  <span style="white-space:nowrap">[&nbsp;${subtitle}&nbsp;]</span>
+                </p>
+                <h2 class="mt-3 text-2xl font-bold text-gray-900 dark:text-slate-100">${title}</h2>
 
-                <div class="mb-6">
-                  <h2 class="text-2xl font-bold text-gray-900 dark:text-slate-100">${title}</h2>
-                  <p class="text-sm text-gray-600 dark:text-slate-400">${subtitle}</p>
-                  ${note ? `<p class="mt-2 text-sm italic text-gray-600 dark:text-slate-400">${note}</p>` : ""}
+                <div class="mt-8">
+                  <h3 class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500 mb-4">Top Tracks</h3>
+                  <ol>
+                    ${tracks.items
+                      .slice(0, 10)
+                      .map(
+                        (track, index) => `
+                      <li class="flex items-center gap-3 py-3 border-b border-gray-200 dark:border-slate-700 last:border-0 group">
+                        <span class="text-xs font-mono text-gray-400 dark:text-slate-500 w-5 text-right">${index + 1}</span>
+                        ${
+                          track.album.images && track.album.images.length > 0
+                            ? `<img src="${track.album.images[track.album.images.length - 1].url}" alt="${track.album.name}" class="w-10 h-10 rounded shadow-xs" />`
+                            : ""
+                        }
+                        <div class="flex-1 min-w-0">
+                          <a href="${track.external_urls.spotify}" target="_blank" rel="noopener noreferrer"
+                            class="block text-sm font-semibold text-red-700 dark:text-red-400 truncate no-underline hover:text-red-800 dark:hover:text-red-300 transition-colors">
+                            ${track.name}
+                          </a>
+                          <p class="text-xs text-gray-500 dark:text-slate-400 truncate">
+                            ${track.artists.map((a) => a.name).join(", ")}
+                          </p>
+                        </div>
+                      </li>
+                    `,
+                      )
+                      .join("")}
+                  </ol>
                 </div>
 
-                <div class="space-y-6">
-                  <div>
-                    <h3 class="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">Top Tracks</h3>
-                    <ol class="space-y-2">
-                      ${tracks.items
-                        .slice(0, 10)
-                        .map(
-                          (track, index) => `
-                        <li class="border-b-2 border-slate-200 last:border-0 flex items-center  gap-3 pb-4 pt-2 hover:bg-white/50 dark:hover:bg-slate-800/50 transition-colors group">
-                          <span class="text-2xl font-bold text-gray-500 dark:text-slate-500 w-6">${index + 1}</span>
+                <div class="mt-8">
+                  <h3 class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500 mb-4">Top Artists</h3>
+                  <ol>
+                    ${artists.items
+                      .slice(0, 10)
+                      .map(
+                        (artist, index) => `
+                      <li class="flex items-center gap-3 py-3 border-b border-gray-200 dark:border-slate-700 last:border-0 group">
+                        <span class="text-xs font-mono text-gray-400 dark:text-slate-500 w-5 text-right">${index + 1}</span>
+                        ${
+                          artist.images && artist.images.length > 0
+                            ? `<img src="${artist.images[artist.images.length - 1].url}" alt="${artist.name}" class="w-10 h-10 rounded-full shadow-xs" />`
+                            : ""
+                        }
+                        <div class="flex-1 min-w-0">
+                          <a href="${artist.external_urls.spotify}" target="_blank" rel="noopener noreferrer"
+                            class="block text-sm font-semibold text-red-700 dark:text-red-400 truncate no-underline hover:text-red-800 dark:hover:text-red-300 transition-colors">
+                            ${artist.name}
+                          </a>
                           ${
-                            track.album.images && track.album.images.length > 0
-                              ? `
-                            <img
-                              src="${track.album.images[track.album.images.length - 1].url}"
-                              alt="${track.album.name}"
-                              class="w-10 h-10 rounded-sm shadow-xs"
-                            />
-                          `
+                            artist.genres && artist.genres.length > 0
+                              ? `<p class="text-xs text-gray-500 dark:text-slate-400 truncate">${artist.genres.slice(0, 2).join(", ")}</p>`
                               : ""
                           }
-                          <div class="flex-1 min-w-0">
-                            <a
-                              href="${track.external_urls.spotify}"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              class="block text-sm font-bold text-gray-900 dark:text-slate-100 truncate group-hover:text-indigo-600 dark:group-hover:text-indigo-400"
-                            >
-                              ${track.name}
-                            </a>
-                            <p class="text-xs text-gray-600 dark:text-slate-400 truncate">
-                              ${track.artists.map((a) => a.name).join(", ")}
-                            </p>
-                          </div>
-                        </li>
-                      `,
-                        )
-                        .join("")}
-                    </ol>
-                  </div>
-
-                  <div>
-                    <h3 class="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">Top Artists</h3>
-                    <ol class="space-y-2">
-                      ${artists.items
-                        .slice(0, 10)
-                        .map(
-                          (artist, index) => `
-                        <li class="border-b-2 border-slate-200 last:border-0 flex items-center gap-3 pb-4 pt-2 rounded-lg hover:bg-white/50 dark:hover:bg-slate-800/50 transition-colors group">
-                          <span class="text-2xl font-bold text-gray-500 dark:text-slate-500 w-6">${index + 1}</span>
-                          ${
-                            artist.images && artist.images.length > 0
-                              ? `
-                            <img
-                              src="${artist.images[artist.images.length - 1].url}"
-                              alt="${artist.name}"
-                              class="w-10 h-10 rounded-full shadow-xs"
-                            />
-                          `
-                              : ""
-                          }
-                          <div class="flex-1 min-w-0">
-                            <a
-                              href="${artist.external_urls.spotify}"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              class="block text-sm font-bold text-gray-900 dark:text-slate-100 truncate group-hover:text-indigo-600 dark:group-hover:text-indigo-400"
-                            >
-                              ${artist.name}
-                            </a>
-                            ${
-                              artist.genres && artist.genres.length > 0
-                                ? `
-                              <p class="text-xs text-gray-600 dark:text-slate-400 truncate">
-                                ${artist.genres.slice(0, 2).join(", ")}
-                              </p>
-                            `
-                                : ""
-                            }
-                          </div>
-                        </li>
-                      `,
-                        )
-                        .join("")}
-                    </ol>
-                  </div>
+                        </div>
+                      </li>
+                    `,
+                      )
+                      .join("")}
+                  </ol>
                 </div>
               </div>
             `;
@@ -289,16 +237,15 @@ export const prerender = true;
         } catch (error) {
           console.error("Error loading music data:", error);
           container.innerHTML = `
-            <div class="col-span-full flex justify-center items-center py-20">
-              <div class="text-red-500 dark:text-red-400">
+            <div class="col-span-full bg-slate-50 dark:bg-slate-800 p-8">
+              <p class="text-red-500 dark:text-red-400">
                 Failed to load music data. Please check your Spotify API credentials.
-              </div>
+              </p>
             </div>
           `;
         }
       }
 
-      // Load data when page loads
       fetchMusicData();
     </script>
   </body>

--- a/src/pages/music/reviews/index.astro
+++ b/src/pages/music/reviews/index.astro
@@ -2,6 +2,7 @@
 import BaseHead from "@/components/BaseHead.astro";
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
+import { SITE_TITLE } from "@/consts";
 import { getCollection } from "astro:content";
 import { ViewTransitions } from "astro:transitions";
 
@@ -10,95 +11,80 @@ export const prerender = true;
 const songs = (await getCollection("songs")).sort((a, b) =>
   a.data.title.localeCompare(b.data.title),
 );
-
-// Format duration from ms to mm:ss
-const formatDuration = (ms: number) => {
-  const minutes = Math.floor(ms / 60000);
-  const seconds = ((ms % 60000) / 1000).toFixed(0);
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-};
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
     <BaseHead
-      title="Music Reviews"
+      title="Music Reviews | Dan Denney"
       description="AI-generated reviews of songs I'm listening to"
     />
     <ViewTransitions />
-    <style>
-      @media screen and (min-width: 1000px) {
-        .reviews-list:has(.review-item:hover) .review-item:not(:hover) {
-          opacity: 0.70;
-        }
-      }
-    </style>
   </head>
   <body class="bg-white dark:bg-slate-900">
-    <Header />
     <main
-      class="bg-white relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200 min-h-screen"
+      class="bg-white relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200"
     >
-      <div class="max-w-(--breakpoint-xl) mx-auto px-4 py-8">
-        <div class="mb-12">
-          <h1
-            class="text-5xl font-bold tracking-tight text-gray-900 dark:text-slate-100 md:text-6xl"
-          >
+      <Header title={SITE_TITLE} />
+
+      <section class="pt-16">
+        <div class="px-8">
+          <p class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+            <span class="whitespace-nowrap">[&nbsp;{songs.length} reviews&nbsp;]</span>
+          </p>
+          <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100">
             Music Reviews
           </h1>
-          <p class="mt-4 text-xl text-gray-600 dark:text-slate-300 max-w-3xl">
-            AI-generated reviews of songs I'm listening to. Each review is
-            automatically created when I share a Spotify link, using ChatGPT to
-            analyze the track's vibe, production, and emotional impact.
+          <p class="mt-4 max-w-2xl text-lg leading-8 text-gray-600 dark:text-slate-100">
+            AI-generated reviews of songs I'm listening to. Each review is automatically created when I share a Spotify link, using ChatGPT to analyze the track.
           </p>
-          <p class="mt-4 has-links">
-            <a
-              href="/music"
-              class="text-blue-600 dark:text-blue-400 hover:underline"
-              >View my listening history</a
-            >
-          </p>
+          <div class="has-links mt-4">
+            <a href="/music" class="text-sm font-semibold text-red-700 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300">View listening history &rarr;</a>
+          </div>
         </div>
 
-        {
-          songs.length === 0 ? (
-            <div class="text-center py-12">
-              <p class="text-gray-600 dark:text-slate-400 text-lg">
-                No song reviews yet. Share a Spotify link in a PR to generate
-                your first review!
-              </p>
-            </div>
-          ) : (
-            <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3 reviews-list lg:gap-12">
-              {songs.map((song) => (
-                <a
-                  href={`/music/reviews/${song.slug}/`}
-                  class="rounded-lg flex gap-4 review-item group transition-opacity duration-1000 ease-in-out"
-                >
-                  {song.data.albumArt && (
-                    <div class="aspect-square rounded-full h-24 w-24 shrink-0 overflow-hidden lg:h-32 lg:w-32">
-                      <img
-                        class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
-                        src={song.data.albumArt}
-                        alt={`Album art for ${song.data.album}`}
-                      />
-                    </div>
-                  )}
-                  <div class="flex flex-col justify-center">
-                    <h2 class="text-md font-bold text-gray-900 dark:text-slate-100 group-hover:text-red-700 dark:group-hover:text-red-400 transition-colors">
-                      {song.data.title}
-                    </h2>
-                    <p class="text-gray-600 text-sm dark:text-slate-400 mt-1">
-                      {song.data.artist}
-                    </p>
+        {songs.length === 0 ? (
+          <div class="mt-12 px-8">
+            <p class="text-gray-600 dark:text-slate-400">
+              No song reviews yet. Share a Spotify link in a PR to generate your first review!
+            </p>
+          </div>
+        ) : (
+          <div class="reviews-list-grid mt-12 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 border-y border-gray-200 dark:border-slate-700">
+            {songs.map((song) => (
+              <a
+                href={`/music/reviews/${song.slug}/`}
+                class="reviews-list-grid-item group flex items-center gap-4 p-6 md:p-8 bg-slate-50 no-underline transition-colors dark:bg-slate-800"
+              >
+                {song.data.albumArt && (
+                  <div class="h-16 w-16 shrink-0 overflow-hidden rounded-full lg:h-20 lg:w-20">
+                    <img
+                      class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-110"
+                      src={song.data.albumArt}
+                      alt={`Album art for ${song.data.album}`}
+                      loading="lazy"
+                    />
                   </div>
-                </a>
-              ))}
-            </div>
-          )
-        }
-      </div>
+                )}
+                <div class="min-w-0 flex-1">
+                  <h2 class="text-sm font-semibold text-red-700 transition-colors group-hover:text-red-800 dark:text-red-400 dark:group-hover:text-red-300 truncate">
+                    {song.data.title}
+                  </h2>
+                  <p class="mt-1 text-xs text-gray-500 dark:text-slate-400 truncate">
+                    {song.data.artist}
+                  </p>
+                  {song.data.album && (
+                    <p class="mt-1 text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500 truncate">
+                      {song.data.album}
+                    </p>
+                  )}
+                </div>
+              </a>
+            ))}
+          </div>
+        )}
+      </section>
     </main>
     <Footer />
   </body>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -9,6 +9,25 @@ import { ViewTransitions } from 'astro:transitions';
 const posts = (await getCollection('posts')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
+
+const blogroll = [
+	{ name: "Rachel Smith", url: "https://rachsmith.com" },
+	{ name: "Chris Coyier", url: "https://chriscoyier.net" },
+	{ name: '"Uncle" Dave Rupert', url: "https://daverupert.com" },
+	{ name: "CSS IRL", url: "https://css-irl.info" },
+	{ name: "Ire Aderinokun", url: "https://bitsofco.de" },
+	{ name: "Stephanie Walter", url: "https://stephaniewalter.design/blog" },
+	{ name: "Tim Kadlec", url: "https://timkadlec.com/remembers" },
+	{ name: "Brad Frost", url: "https://bradfrost.com/blog" },
+	{ name: "Modern CSS Solutions", url: "https://moderncss.dev" },
+	{ name: "CoDrops", url: "https://tympanus.net/codrops" },
+	{ name: "Raymond Camden", url: "https://www.raymondcamden.com" },
+	{ name: "Ahmad Shadeed", url: "https://ishadeed.com/articles" },
+	{ name: "Builder", url: "https://www.builder.io/blog" },
+	{ name: "Zach Leat", url: "https://www.zachleat.com/web" },
+	{ name: "Stefan Judis", url: "https://www.stefanjudis.com/blog" },
+	{ name: "Web.Dev", url: "https://web.dev/blog" },
+];
 ---
 <!doctype html>
 <html lang="en">
@@ -17,86 +36,96 @@ const posts = (await getCollection('posts')).sort(
 		<ViewTransitions />
 	</head>
 	<body class="bg-white dark:bg-slate-900">
-		<main class="bg-white relative shadow-xs  z-10 dark:bg-slate-900 dark:text-slate-200">
-			<section class="relative isolate overflow-hidden pb-16">
+		<main class="bg-white relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200">
+			<Header title={SITE_TITLE} />
 
-				<Header title={SITE_TITLE} />
-				<div class="mx-auto max-w-7xl pt-16 px-6 lg:px-8">
-					<div class="mx-auto max-w-2xl lg:mx-0">
-						<p class="text-lg font-semibold leading-8 tracking-tight text-slate-400">The Ol' Blog</p>
-						<h1 class="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100">Posts, aka Blog Posts</h1>
-						<p class="has-links mt-4 text-xl leading-8 text-gray-700 dark:text-slate-100">Below is a <a href="#list">list of posts</a> that I really wanted to share or that I felt compelled to write because I didn't find it when I was looking. It seems that I'm up to <strong class="font-semibold">{posts.length }</strong> that have survived refactors and redesigns since 2012.</p>
-					</div>
-					<div class="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 lg:mx-0 lg:mt-8 lg:max-w-none lg:grid-cols-12">
-						<div class="relative lg:order-last lg:col-span-5">
-							<svg class="absolute -top-160 left-1 -z-10 h-256 w-702 -translate-x-1/2 stroke-gray-900/10 mask-[radial-gradient(64rem_64rem_at_111.5rem_0%,white,transparent)]" aria-hidden="true">
-								<defs>
-									<pattern id="e87443c8-56e4-4c20-9111-55b82fa704e3" width="200" height="200" patternUnits="userSpaceOnUse">
-										<path d="M0.5 0V200M200 0.5L0 0.499983" />
-									</pattern>
-								</defs>
-								<rect width="100%" height="100%" stroke-width="0" fill="url(#e87443c8-56e4-4c20-9111-55b82fa704e3)" />
-							</svg>
-							<figure class="border-l border-slate-500 mt-8 pl-8">
-								<blockquote class="text-xl font-semibold leading-8 tracking-tight text-gray-900 dark:text-slate-100">
-									<p>“Write the article you wish you found when you googled something.”</p>
-								</blockquote>
-								<figcaption class="mt-8 flex gap-x-4">
-									<img src="/chris-coyier.jpg" alt="Chris Coyier" class="mt-1 h-10 w-10 flex-none rounded-full bg-gray-50">
-									<div class="has-links text-sm leading-6">
-										<div class="font-semibold text-gray-900 dark:text-slate-300">Chris Coyier</div>
-										<a class="text-gray-600" href="https://twitter.com/chriscoyier/status/925102888610775041">@chriscoyier</a>
-									</div>
-								</figcaption>
-							</figure>
+			<section class="pt-16 pb-24">
+				<div class="px-8">
+					<p class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+						<span class="whitespace-nowrap">[&nbsp;{posts.length} posts&nbsp;]</span>
+					</p>
+					<h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100">Posts, aka Blog Posts</h1>
+					<p class="has-links mt-4 max-w-2xl text-lg leading-8 text-gray-600 dark:text-slate-100">
+						Articles I really wanted to share or felt compelled to write because I didn't find what I was looking for. They've survived refactors and redesigns since 2012.
+					</p>
+				</div>
+
+				<div class="posts-intro-grid mt-12 grid grid-cols-1 md:grid-cols-2 border-y border-gray-200 dark:border-slate-700">
+					<figure class="flex items-center gap-6 bg-white p-8 dark:bg-slate-900">
+						<img src="/chris-coyier.jpg" alt="Chris Coyier" class="h-12 w-12 flex-none rounded-full bg-gray-50" />
+						<div>
+							<blockquote class="text-base font-semibold leading-7 text-gray-900 dark:text-slate-100">
+								<p>"Write the article you wish you found when you googled something."</p>
+							</blockquote>
+							<figcaption class="has-links mt-1 text-sm text-gray-500 dark:text-slate-400">
+								Chris Coyier · <a href="https://twitter.com/chriscoyier/status/925102888610775041">@chriscoyier</a>
+							</figcaption>
 						</div>
-						<div class="max-w-xl text-base leading-7 text-gray-700 lg:col-span-7 dark:text-slate-100">
-							<p>While I'm glad you have the interest in checking out my blog, I want to help bring back this old tradition of sharing links to other people's blogs, via a blog roll. The decline of a single place, like Twitter, where lots of web folks share their links makes it even more important to have ways of finding great blogs.</p>
-							<nav class="has-links flex flex-wrap gap-x-4 mt-6">
-								<a class="mt-2" href="https://rachsmith.com">Rachel Smith</a>
-								<a class="mt-2" href="https://chriscoyier.net">Chris Coyier</a>
-								<a class="mt-2" href="https://daverupert.com">"Uncle" Dave Rupert</a>
-								<a class="mt-2" href="https://css-irl.info">CSS IRL</a>
-								<a class="mt-2" href="https://bitsofco.de">Ire Aderinokun</a>
-								<a class="mt-2" href="https://stephaniewalter.design/blog">Stephanie Walter</a>
-								<a class="mt-2" href="https://timkadlec.com/remembers">Tim Kadlec</a>
-								<a class="mt-2" href="https://bradfrost.com/blog">Brad Frost</a>
-								<a class="mt-2" href="https://moderncss.dev">Modern CSS Solutions</a>
-								<a class="mt-2" href="https://tympanus.net/codrops">CoDrops</a>
-								<a class="mt-2" href="https://www.raymondcamden.com">Raymond Camden</a>
-								<a class="mt-2" href="https://ishadeed.com/articles">Ahmad Shadeed</a>
-								<a class="mt-2" href="https://www.builder.io/blog">Builder</a>
-								<a class="mt-2" href="https://www.zachleat.com/web">Zach Leat</a>
-								<a class="mt-2" href="https://www.stefanjudis.com/blog">Stefan Judis</a>
-								<a class="mt-2" href="https://web.dev/blog">Web.Dev</a>
-							</nav>
-						</div>
+					</figure>
+					<div class="bg-white p-8 dark:bg-slate-900">
+						<h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+							<span class="whitespace-nowrap">[&nbsp;Blog Roll&nbsp;]</span>
+						</h2>
+						<nav class="mt-3 flex flex-wrap gap-x-4 gap-y-1">
+							{blogroll.map((blog) => (
+								<a
+									href={blog.url}
+									class="text-sm font-semibold text-red-700 no-underline transition-colors hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+								>
+									{blog.name}
+								</a>
+							))}
+						</nav>
 					</div>
 				</div>
-			</section>
 
-
-			<section class="pb-16" id="list">
-				<div class="mx-auto max-w-7xl px-6 lg:px-8">
-					<div class="mx-auto grid max-w-2xl auto-rows-fr grid-cols-1 gap-8 sm:mt-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-
-						{posts.map((post) => (
-							<article class="relative isolate flex flex-col justify-end overflow-hidden rounded-2xl bg-gray-900 px-8 pb-8 pt-80 sm:pt-48 lg:pt-80 transition-all duration-300 hover:scale-[1.02] hover:shadow-xl group">
-								<a href={`/posts/${post.slug}/`} class="absolute inset-0 z-20">
-									<span class="sr-only">Read {post.data.title}</span>
-								</a>
-								{post.data.cloudinaryThumb ? <img class="absolute inset-0 -z-10 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105" loading="lazy" src={`https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_686,q_auto/v1673896360/${post.data.cloudinaryThumb}`} alt={post.data.thumbAlt || post.data.title} srcset={`https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_686,q_auto/v1673896360/${post.data.cloudinaryThumb} 375w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_704,q_auto/v1673896360/${post.data.cloudinaryThumb} 768w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_896,q_auto/v1673896360/${post.data.cloudinaryThumb} 1200w`} /> : post.data.thumb ? <img class="absolute inset-0 -z-10 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105" loading="lazy" src={post.data.thumb} alt={post.data.thumbAlt || post.data.title} /> : <img class="absolute inset-0 -z-10 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105" loading="lazy" src="https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_686,q_auto/v1673896360/posts/slackin.png" alt="Placeholder image" srcset="https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_686,q_auto/v1673896360/posts/slackin.png 375w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_704,q_auto/v1673896360/posts/slackin.png 768w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_896,q_auto/v1673896360/posts/slackin.png 1200w" /> }
-								<div class="absolute inset-0 -z-10 bg-linear-to-t from-gray-900 via-gray-900/40 transition-opacity duration-300 group-hover:opacity-90"></div>
-								<div class="absolute inset-0 -z-10 rounded-2xl ring-1 ring-inset ring-gray-900/10 transition-shadow duration-300 group-hover:ring-gray-900/20"></div>
-								<h3 class="mt-3 text-lg font-semibold leading-6 text-white transition-transform duration-300 group-hover:translate-y-[-2px]">
-									{post.data.title}
-								</h3>
-								<p class="mt-2 text-sm text-gray-300 transition-transform duration-300 group-hover:translate-y-[-2px]">{post.data.summary}</p>
-							</article>
-							))
-						}
-
-					</div>
+				<div class="mt-0">
+					<div class="posts-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 border-b border-gray-200 dark:border-slate-700" id="list">
+							{posts.map((post, i) => {
+								const wideIndices = new Set([0, 5, 11, 18, 24, 31, 37, 44]);
+								const isWide = wideIndices.has(i);
+								return (
+									<article
+										class:list={[
+											"group relative isolate flex flex-col justify-end overflow-hidden bg-gray-900 px-8 pb-8 pt-48 sm:pt-32 lg:pt-48 transition-all duration-300 hover:shadow-md",
+											isWide ? "sm:col-span-2" : "",
+										]}
+									>
+										<a href={`/posts/${post.slug}/`} class="absolute inset-0 z-20">
+											<span class="sr-only">Read {post.data.title}</span>
+										</a>
+										{post.data.cloudinaryThumb ? (
+											<img
+												class="absolute inset-0 -z-10 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+												loading="lazy"
+												src={`https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_686,q_auto/v1673896360/${post.data.cloudinaryThumb}`}
+												alt={post.data.thumbAlt || post.data.title}
+												srcset={`https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_686,q_auto/v1673896360/${post.data.cloudinaryThumb} 375w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_704,q_auto/v1673896360/${post.data.cloudinaryThumb} 768w, https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_896,q_auto/v1673896360/${post.data.cloudinaryThumb} 1200w`}
+											/>
+										) : post.data.thumb ? (
+											<img
+												class="absolute inset-0 -z-10 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+												loading="lazy"
+												src={post.data.thumb}
+												alt={post.data.thumbAlt || post.data.title}
+											/>
+										) : (
+											<img
+												class="absolute inset-0 -z-10 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+												loading="lazy"
+												src="https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_686,q_auto/v1673896360/posts/slackin.png"
+												alt="Placeholder image"
+											/>
+										)}
+										<div class="absolute inset-0 -z-10 bg-linear-to-t from-gray-900 via-gray-900/40 transition-opacity duration-300 group-hover:opacity-90" />
+										<h3 class="mt-3 text-lg font-semibold leading-6 text-white transition-transform duration-300 group-hover:translate-y-[-2px]">
+											{post.data.title}
+										</h3>
+										<p class="mt-2 text-sm text-gray-300 transition-transform duration-300 group-hover:translate-y-[-2px]">{post.data.summary}</p>
+									</article>
+								);
+							})}
+						</div>
 				</div>
 			</section>
 		</main>

--- a/src/pages/tinkerings/index.astro
+++ b/src/pages/tinkerings/index.astro
@@ -2,54 +2,86 @@
 import BaseHead from '../../components/BaseHead.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
+import { SITE_TITLE } from '../../consts';
 import { getCollection } from 'astro:content';
+import { ViewTransitions } from 'astro:transitions';
 
 const tinkerings = (await getCollection('tinkerings')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
 ---
-
 <!doctype html>
 <html lang="en">
 	<head>
 		<BaseHead title="Tinkerings | Dan Denney" description="Projects with some technical bit that I learned in order to create" />
+		<ViewTransitions />
 	</head>
 	<body class="bg-white dark:bg-slate-900">
-		<Header />
 		<main class="bg-white relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200">
-			<section class="pb-24 pt-16 relative shadow-xs z-10 sm:pb-32">
-				<div class="mx-auto max-w-7xl px-6 lg:px-8">
-					<div class="mx-auto max-w-2xl lg:max-w-4xl">
-						<p class="text-lg font-semibold leading-8 tracking-tight text-slate-400 dark:text-slate-400">This Used To Be My Playground</p>
-						<h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl dark:text-slate-100">Tinkerings</h1>
-						<p class="relative mt-6 text-lg leading-8 text-gray-600 sm:max-w-md lg:max-w-none dark:text-slate-100">
-							The projects are all scratching some itch, either technical or part of my interests. Each has some technical bit that I learned in order to build, but they're focused on things like my love for music and trying to beat number systems.
-						</p>
-						<div class="mt-16 space-y-20 lg:mt-20 lg:space-y-20">
-							{tinkerings.map((tinkering) => (
-								<article class="relative isolate flex flex-col gap-8 lg:flex-row lg:items-center">
-									<div class="relative aspect-video sm:aspect-2/1 lg:aspect-square lg:w-48 lg:shrink-0">
-										<img src={`https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_880,q_auto/${tinkering.data.thumb ? tinkering.data.thumb : 'posts/slackin.png'}`} alt="{% if tinkering.data.thumb %}{{ tinkering.data.thumbAlt }}{% else %}slacking on my imagin'{% endif %}" class="absolute inset-0 h-full w-full rounded-2xl bg-gray-50 object-cover" />
-										<div class="absolute inset-0 rounded-2xl ring-1 ring-inset ring-gray-900/10"></div>
+			<Header title={SITE_TITLE} />
+
+			<section class="pt-16 pb-24">
+				<div class="px-8">
+					<p class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+						<span class="whitespace-nowrap">[&nbsp;{tinkerings.length} projects&nbsp;]</span>
+					</p>
+					<h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100">Tinkerings</h1>
+					<p class="mt-4 max-w-2xl text-lg leading-8 text-gray-600 dark:text-slate-100">
+						Each scratches some itch, either technical or personal. Projects focused on things like my love for music and trying to beat number systems.
+					</p>
+				</div>
+
+				<div class="tinkerings-grid mt-12 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 border-y border-gray-200 dark:border-slate-700">
+					{tinkerings.map((tinkering, i) => {
+						const wideIndices = new Set([0, 5]);
+						const isWide = wideIndices.has(i);
+						const dateStr = tinkering.data.pubDate.toLocaleDateString('en-US', {
+							month: 'short',
+							day: 'numeric',
+							year: 'numeric',
+						});
+						const thumbUrl = tinkering.data.thumb
+							? `https://res.cloudinary.com/dtlow08pj/image/upload/f_auto,c_limit,w_600,q_auto/${tinkering.data.thumb}`
+							: null;
+						return (
+							<a
+								href={`/tinkerings/${tinkering.slug}/`}
+								class:list={[
+									"tinkerings-grid-item group relative flex flex-col no-underline bg-slate-50 dark:bg-slate-800",
+									isWide ? "md:col-span-2" : "",
+								]}
+							>
+								{thumbUrl && (
+									<div class="aspect-video overflow-hidden">
+										<img
+											src={thumbUrl}
+											alt={tinkering.data.thumbAlt || tinkering.data.title}
+											class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+											loading="lazy"
+										/>
 									</div>
-									<div>
-										<div class="group relative max-w-xl">
-											<h3 class="has-links mt-3 text-lg font-semibold leading-6 text-gray-900 group-hover:text-gray-600">
-												<a href={`/tinkerings/${tinkering.slug}/`}>
-													<span class="absolute inset-0"></span>
-													{tinkering.data.title}
-												</a>
-											</h3>
-											<p class="mt-2 text-sm leading-6 text-gray-600 dark:text-slate-300">
+								)}
+								<div class="flex flex-1 items-start justify-between gap-4 p-6 md:p-8">
+									<div class="min-w-0 flex-1">
+										<p class="text-xs font-mono uppercase tracking-widest text-gray-400 dark:text-slate-500">
+											<span class="whitespace-nowrap">[&nbsp;{dateStr}&nbsp;]</span>
+										</p>
+										<h3 class="mt-3 text-lg font-semibold leading-snug text-red-700 transition-colors group-hover:text-red-800 dark:text-red-400 dark:group-hover:text-red-300">
+											{tinkering.data.title}
+										</h3>
+										{tinkering.data.summary && (
+											<p class="mt-3 text-sm leading-relaxed text-gray-500 dark:text-slate-400">
 												{tinkering.data.summary}
 											</p>
-										</div>
+										)}
 									</div>
-								</article>
-								))
-							}
-						</div>
-					</div>
+									<svg class="shrink-0 mt-1 text-gray-300 transition-colors group-hover:text-red-400 dark:text-slate-600 dark:group-hover:text-red-400" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+										<path d="M5 10h10M11 6l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+									</svg>
+								</div>
+							</a>
+						);
+					})}
 				</div>
 			</section>
 		</main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -281,15 +281,66 @@
   @apply rounded-md bg-red-600 px-3.5 py-2.5 text-sm font-semibold text-white transition-colors transition-transform shadow-xs hover:bg-red-500 hover:scale-105 focus-visible:scale-105 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500;
 }
 
-/* Finds Grid - internal borders only */
+/* Grid shared — diagonal lines for empty cells, solid borders between items */
 
-.finds-grid {
+.finds-grid,
+.blips-grid,
+.tinkerings-grid,
+.music-grid,
+.reviews-list-grid,
+.reviews-grid,
+.posts-grid,
+.posts-intro-grid {
   gap: 1px;
-  background: #e2e8f0; /* slate-200 - the "border" color */
+  background-color: transparent;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 4px,
+    #cbd5e1 4px,
+    #cbd5e1 5px
+  );
 }
 
-.dark .finds-grid {
-  background: #334155; /* slate-700 */
+.dark .finds-grid,
+.dark .blips-grid,
+.dark .tinkerings-grid,
+.dark .music-grid,
+.dark .reviews-list-grid,
+.dark .reviews-grid,
+.dark .posts-grid,
+.dark .posts-intro-grid {
+  background-color: transparent;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 4px,
+    #1e293b 4px,
+    #1e293b 5px
+  );
+}
+
+/* Solid borders between grid items via box-shadow */
+.finds-grid > *,
+.blips-grid > *,
+.tinkerings-grid > *,
+.music-grid > *,
+.reviews-list-grid > *,
+.reviews-grid > *,
+.posts-grid > *,
+.posts-intro-grid > * {
+  box-shadow: 0 0 0 0.5px #e2e8f0;
+}
+
+.dark .finds-grid > *,
+.dark .blips-grid > *,
+.dark .tinkerings-grid > *,
+.dark .music-grid > *,
+.dark .reviews-list-grid > *,
+.dark .reviews-grid > *,
+.dark .posts-grid > *,
+.dark .posts-intro-grid > * {
+  box-shadow: 0 0 0 0.5px #334155;
 }
 
 .finds-grid-item {
@@ -297,25 +348,22 @@
 }
 
 .finds-grid-item:hover,
-.blips-grid-item:hover {
+.blips-grid-item:hover,
+.tinkerings-grid-item:hover,
+.music-grid-item:hover,
+.reviews-list-grid-item:hover {
   background-color: #ffffff !important;
 }
 
 .dark .finds-grid-item:hover,
-.dark .blips-grid-item:hover {
+.dark .blips-grid-item:hover,
+.dark .tinkerings-grid-item:hover,
+.dark .music-grid-item:hover,
+.dark .reviews-list-grid-item:hover {
   background-color: #0f172a !important;
 }
 
 /* Blips Grid */
-
-.blips-grid {
-  gap: 1px;
-  background: #e2e8f0;
-}
-
-.dark .blips-grid {
-  background: #334155;
-}
 
 .blips-grid-item {
   transition: background-color 0.2s ease;
@@ -383,16 +431,25 @@
   }
 }
 
+/* Tinkerings Grid */
+
+.tinkerings-grid-item {
+  transition: background-color 0.2s ease;
+}
+
+/* Music Grid */
+
+.music-grid-item {
+  transition: background-color 0.2s ease;
+}
+
+/* Reviews List Grid */
+
+.reviews-list-grid-item {
+  transition: background-color 0.2s ease;
+}
+
 /* Reviews Grid */
-
-.reviews-grid {
-  gap: 1px;
-  background: #e2e8f0;
-}
-
-.dark .reviews-grid {
-  background: #334155;
-}
 
 .reviews-grid-item {
   transition: background-color 0.2s ease;


### PR DESCRIPTION
## Summary

Redesigned all listing pages (/blips/, /tinkerings/, /music/, /music/reviews/) to match the homepage grid design language established in PR #27.

**Key changes:**
- Full-width `px-8` layout with bracketed metadata in mono font
- 3-column grids with internal-only borders using 1px CSS gaps
- Added subtle diagonal line pattern for empty cells (instead of solid gray)
- Solid borders between items via `box-shadow` technique
- Bracketed item counts and dates with non-breaking spaces
- Red titles with hover state transitions
- White background on hover (light mode), dark slate on hover (dark mode)
- Removed bottom padding from music pages for consistency

**Updated files:**
- `/blips/` - redesigned grid with radar SVG identity
- `/tinkerings/` - redesigned with thumbnails and arrow icons
- `/music/` - Spotify listening history with 3-time-range grid
- `/music/reviews/` - song reviews grid with album art
- `/posts/` - aligned existing design to new patterns
- Global CSS - unified grid styling, shared border pattern

🎨 Generated with [Claude Code](https://claude.com/claude-code)