### PR TITLE
refactor: redesign no-reserv-ai-tions pages with full-width layouts

### DIFF
--- a/src/layouts/Review.astro
+++ b/src/layouts/Review.astro
@@ -13,77 +13,98 @@ const { city, description, state, tags, heroImageAlt, heroImage, heroImageUrl, h
 		<BaseHead title={title} description={description} />
 		<ViewTransitions />
 		<style>
-			@media screen and (min-width: 768px) {
-				.longform {
-					font-size: 1.25rem;
-				}
+			.hero-image-wrapper {
+				overflow: hidden;
+			}
+			.hero-image-wrapper img {
+				transition: transform 0.6s ease-out;
 			}
 		</style>
 	</head>
-	<body class="bg-white dark:bg-slate-900">
+	<body class="bg-slate-100 dark:bg-slate-950">
 		<Header />
-		<main class="bg-white relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200">
-			<article class="max-w-(--breakpoint-xl) mx-auto px-4 pt-4">
+		<main class="bg-slate-100 border-b border-slate-200 relative shadow-xs z-10 dark:bg-slate-950 dark:border-slate-800">
 
-				<h1 class="text-4xl font-bold leading-tight max-w-2xl my-8 tracking-tight xl:my-16 md:text-6xl xl:text-8xl">{title}</h1>
+			<!-- Title section: centered on gray background -->
+			<div class="bg-slate-100 px-4 pt-8 dark:bg-slate-950 lg:px-8 lg:pt-16">
+				<div class="max-w-(--breakpoint-xl) mx-auto text-center">
+					<p class="has-links text-sm text-gray-500 dark:text-slate-400">
+						<a href={`/no-reserv-ai-tions/cities/${city}`}>{toTitleCase(city)}</a>{state && <>, <a href={`/no-reserv-ai-tions/states/${state}`}>{toTitleCase(state)}</a></>}
+					</p>
 
-				<div class="w-full md:flex md:justify-end md:pr-12">
-					<div class="max-w-lg">
-						<p class="lg:text-xl">{description}</p>
-						<ul class="has-links flex flex-wrap font-decorative gap-x-4 text-sm">
-							<li class="text-gray-600 mt-4 dark:text-slate-100"><a href={`/no-reserv-ai-tions/cities/${city}`}>{toTitleCase(city)}</a>{state && <>, <a href={`/no-reserv-ai-tions/states/${state}`}>{toTitleCase(state)}</a></> }</li>
-							<li class="mt-4 text-gray-300 dark:text-slate-100">
-								{tags && tags.map((tag, index) => (
-									<>
-										{index > 0 ? '• ' : ''}
-										<a href={`/no-reserv-ai-tions/${tag}`}>{toTitleCase(tag)}</a>
-									</>
-								))}
-							</li>
-						</ul>
+					<h1 class="text-4xl text-balance font-bold leading-tight max-w-3xl mx-auto mt-4 tracking-tight md:text-6xl xl:text-7xl dark:text-white">{title}</h1>
+
+					<p class="mt-4 text-balance max-w-2xl mx-auto text-lg text-gray-600 dark:text-slate-300 lg:text-xl">{description}</p>
+
+					{tags && (
+						<p class="has-links mt-4 text-sm text-gray-400 dark:text-slate-500">
+							{tags.map((tag, index) => (
+								<>
+									{index > 0 ? ' · ' : ''}
+									<a href={`/no-reserv-ai-tions/${tag}`}>{toTitleCase(tag)}</a>
+								</>
+							))}
+						</p>
+					)}
+				</div>
+			</div>
+
+			<!-- Image + white card: card starts behind the image, image sits on top -->
+			<div class="relative px-4 pt-8 lg:px-8 lg:pt-12">
+				<!-- White card: starts partway up the image area -->
+				<div class="absolute inset-x-4 -bottom-4 top-[40%] bg-white rounded-t-2xl dark:bg-slate-900 lg:inset-x-8"></div>
+
+				<!-- Image: narrower than the card, layered on top -->
+				<div class="hero-image-wrapper relative z-10 max-w-5xl mx-auto rounded-lg" id="hero-wrapper">
+					<img
+						class="w-full rounded-lg"
+						id="photo"
+						src={`/no-reserv-ai-tions/${heroImage}.webp`}
+						alt={heroImageAlt}
+					/>
+				</div>
+				{heroImageAttribution && (
+					<div class="has-links relative z-10 max-w-5xl mx-auto mt-2 text-center">
+						<small class="text-xs text-slate-500">Photo credit: <a href={heroImageUrl}>{heroImageAttribution}</a></small>
 					</div>
-				</div>
+				)}
+			</div>
 
-				<div class="my-8 xl:my-16 xl:flex xl:justify-end">
-					<figure class="has-links flex flex-col items-end">
-						<img class="w-9/12 md:min-w-[50%] md:w-6/12" id="photo" src={`/no-reserv-ai-tions/${heroImage}.webp`} alt={heroImageAlt} />
-						{heroImageAttribution && (
-							<small class="mt-8 text-xs text-slate-600">Photo credit: <a href={heroImageUrl}>{heroImageAttribution}</a></small>
-						)}
-					</figure>
-				</div>
+			<!-- White content card: continues seamlessly from the background above -->
+			<div class="px-4 lg:px-8">
+				<article class="bg-white dark:bg-slate-900 mx-auto rounded-b-2xl px-6 pt-4 pb-12 shadow-sm lg:px-16 lg:pt-6 lg:pb-16 xl:px-24">
+					<div class="longform review max-w-3xl mx-auto">
+						<slot />
+					</div>
+				</article>
+			</div>
 
-				<div class="longform review max-w-3xl mx-auto pb-12 lg:pb-24">
-					<slot />
-				</div>
+			<nav class="has-links flex flex-wrap gap-x-4 justify-end max-w-3xl mx-auto px-4 py-12 text-gray-600 lg:py-16 dark:text-slate-300">
+				<a href="/no-reserv-ai-tions" class="btn-link">← Back to No Reserv-AI-tions</a>
+				<p class="mt-2">Or view by <a href="/no-reserv-ai-tions/1">newest</a>, <a href="/no-reserv-ai-tions/cities">city</a>, <a href="/no-reserv-ai-tions/states">state</a>, or <a href="/no-reserv-ai-tions/tags">tag</a></p>
+			</nav>
 
-				<nav class="flex flex-wrap gap-x-4 justify-end pb-12 lg:pb-24">
-					<a href="/no-reserv-ai-tions" class="btn-link ">← Back to No Reserv-AI-tions</a>
-					<p class="has-links mt-2">Or view by <a href="/no-reserv-ai-tions/1">newest</a>, <a href="/no-reserv-ai-tions/cities">city</a>, <a href="/no-reserv-ai-tions/states">state</a>, or <a href="/no-reserv-ai-tions/tags">tag</a></p>
-				</nav>
-
-				<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.10.4/gsap.min.js" is:inline></script>
-				<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.10.4/ScrollTrigger.min.js" is:inline></script>
-
-				<script is:inline>
-					document.addEventListener('astro:page-load', () => {
-						gsap.registerPlugin(ScrollTrigger);
-
-						gsap.to("#photo", {
-							transformOrigin: "100% 0",
-							width: '100%',
-							scrollTrigger: {
-								trigger: "#photo",
-								start: "top center",
-								end: "top top",
-								scrub: true
-							}
-						});
-					});
-				</script>
-
-			</article>
 		</main>
 		<Footer />
+
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" is:inline></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" is:inline></script>
+
+		<script is:inline>
+			document.addEventListener('astro:page-load', () => {
+				gsap.registerPlugin(ScrollTrigger);
+
+				gsap.to("#photo", {
+					yPercent: -8,
+					ease: "none",
+					scrollTrigger: {
+						trigger: "#hero-wrapper",
+						start: "top bottom",
+						end: "bottom top",
+						scrub: true
+					}
+				});
+			});
+		</script>
 	</body>
 </html>

--- a/src/pages/no-reserv-ai-tions/cities/index.astro
+++ b/src/pages/no-reserv-ai-tions/cities/index.astro
@@ -8,29 +8,99 @@ import { ViewTransitions } from 'astro:transitions';
 export const prerender = true;
 
 const allReviews = await Astro.glob('../../../content/reviews/*.md');
-// Dedupe by lowercase so "Nashville" and "nashville" show as one city
-const cities = [...new Set(allReviews.map((review) => String(review.frontmatter.city).toLowerCase()))].sort();
 
+// Build city data: name, review count, and a representative image
+const cityMap = new Map();
+for (const review of allReviews) {
+	const cityKey = String(review.frontmatter.city).toLowerCase();
+	if (!cityMap.has(cityKey)) {
+		cityMap.set(cityKey, {
+			name: cityKey,
+			count: 0,
+			image: review.frontmatter.heroImage,
+			imageAlt: review.frontmatter.heroImageAlt,
+			state: review.frontmatter.state,
+			country: review.frontmatter.country,
+		});
+	}
+	cityMap.get(cityKey).count++;
+}
+
+const cities = [...cityMap.values()].sort((a, b) => b.count - a.count);
 ---
 <!doctype html>
 <html lang="en">
 	<head>
 		<BaseHead title="No ReservAItions Cities | Dan Denney" description="Reviews of food, music, and events with the help of AI" />
 		<ViewTransitions />
+		<style>
+			.city-card {
+				transition: transform 0.3s ease, box-shadow 0.3s ease;
+			}
+			.city-card:hover {
+				transform: translateY(-4px);
+				box-shadow: 0 12px 32px rgba(0, 0, 0, 0.3);
+			}
+			.city-card:hover img {
+				transform: scale(1.08);
+			}
+			.city-card img {
+				transition: transform 0.6s ease;
+			}
+			.city-card:hover .city-overlay {
+				background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
+			}
+			.city-overlay {
+				background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.1) 50%, transparent 100%);
+				transition: background 0.3s ease;
+			}
+		</style>
 	</head>
 	<body class="bg-slate-50 dark:bg-slate-900">
 		<Header />
-		<main class="bg-slate-50 relative shadow-xs z-10 xl:flex dark:bg-slate-900 dark:text-slate-200" style="min-height: 90dvh;">  
-      <section class="max-w-(--breakpoint-xl) mx-auto pb-24 pt-8 px-4">
-				<h2 class="border-b text-center text-4xl font-bold pb-4 tracking-tight text-gray-900 dark:text-slate-100 md:shrink-0 md:text-left xl:border-0 xl:text-6xl">Cities</h2>
-        <p class="mt-2 text-gray-600 dark:text-slate-100">Cities with reviews of food, music, and events with the help of AI</p>
-        <nav class="has-links flex flex-wrap items-start mt-8 gap-x-8 gap-y-4 xl:gap-x-12 xl:gap-y-8">
-          {cities.map((city) => (
-            <a class="md:text-2xl xl:text-4xl" href={`/no-reserv-ai-tions/cities/${city}`}>{toTitleCase(city)}</a>
-          ))}
-        </nav>
-      </section>
-    </main>
-    <Footer />
-  </body>
+		<main class="bg-slate-50 relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200" style="min-height: 90dvh;">
+			<section class="mx-auto pb-24 pt-8 px-4 max-w-(--breakpoint-2xl)">
+				<div class="mb-8">
+					<h2 class="text-4xl font-bold tracking-tight text-gray-900 dark:text-slate-100 xl:text-6xl">Cities</h2>
+					<p class="mt-2 text-gray-600 dark:text-slate-300">
+						<span class="whitespace-nowrap">[&nbsp;{cities.length} cities, {allReviews.length} reviews — AI-written in the spirit of Anthony Bourdain&nbsp;]</span>
+					</p>
+				</div>
+
+				<nav class="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:gap-4">
+					{cities.map((city, i) => {
+						const isLarge = i < 3;
+						return (
+							<a
+								href={`/no-reserv-ai-tions/cities/${city.name}`}
+								class:list={[
+									"city-card relative block overflow-hidden rounded-lg",
+									isLarge ? "aspect-[4/5] md:col-span-1 lg:first:col-span-2 lg:first:row-span-2" : "aspect-square",
+								]}
+							>
+								<img
+									src={`/no-reserv-ai-tions/${city.image}.webp`}
+									alt={city.imageAlt}
+									class="absolute inset-0 h-full w-full object-cover"
+									loading={i < 8 ? "eager" : "lazy"}
+								/>
+								<div class="city-overlay absolute inset-0 flex flex-col justify-end p-4 lg:p-6">
+									<h3 class="text-xl font-bold text-white leading-tight lg:text-2xl xl:text-3xl">
+										{toTitleCase(city.name)}
+									</h3>
+									<p class="text-sm text-white/80 mt-1">
+										{city.country === 'United States' && city.state ? toTitleCase(city.state) : city.country}
+										<span class="ml-2 inline-block rounded-full bg-white/20 px-2 py-0.5 text-xs text-white backdrop-blur-sm">
+											{city.count} {city.count === 1 ? 'review' : 'reviews'}
+										</span>
+									</p>
+								</div>
+							</a>
+						);
+					})}
+				</nav>
+			</section>
+		</main>
+		<Footer />
+	</body>
 </html>

--- a/src/pages/no-reserv-ai-tions/index.astro
+++ b/src/pages/no-reserv-ai-tions/index.astro
@@ -56,9 +56,9 @@ const reviews = (await getCollection('reviews')).sort(
 	</head>
 	<body class="bg-white dark:bg-slate-900">
 		<Header />
-		<main class="bg-white relative shadow-xs z-10 lg:flex lg:items-center dark:bg-slate-900 dark:text-slate-200" style="min-height: 90dvh;">
-			<div class="max-w-(--breakpoint-xl) mx-auto px-4 py-4 lg:grid lg:grid-cols-2 lg:gap-8">
-				<div>
+		<main class="bg-white relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200" style="min-height: 90dvh;">
+			<div class="lg:grid lg:grid-cols-2">
+				<div class="px-4 py-4 lg:px-12 xl:px-16">
 					<div class="sticky top-24">
 						<h1>
 							<span class="sr-only">No Reserv<span class="uppercase">ai</span>tions</span>
@@ -132,7 +132,7 @@ const reviews = (await getCollection('reviews')).sort(
 							{reviews.map((review) => (
 								<li class="mt-8 md:flex lg:col-start-1 lg:mt-0 lg:row-start-1">
 									<a class="review-link block duration-300 group relative isolate transition-all sm:mt-0" href={`/no-reserv-ai-tions/${review.slug}/`}>
-										<div class="max-w-2xl mx-auto sm:gap-8 lg:max-w-(--breakpoint-2xl) sm:flex sm:items-start">
+										<div class="max-w-2xl mx-auto sm:gap-8 sm:flex sm:items-start">
 											<img class="mb-4 sm:max-w-[240px] sm:h-auto lg:hidden" src={`/no-reserv-ai-tions/${review.data.heroImage}.webp`} alt={review.data.heroImageAlt} />
 											<div>
 												<div class="flex items-center gap-x-4 text-sm dark:text-white">
@@ -156,12 +156,12 @@ const reviews = (await getCollection('reviews')).sort(
 				<div>
 					<ul id="images" class="hidden mb-24 lg:block">
 						<li class="photo-container overflow-hidden min-h-[70dvh]">
-							<img alt="Midjourney generated image of Anthony Bourdain in Nashville" class="h-full w-full object-cover" src="/no-reserv-ai-tions/ai-nthony-bourd-ai-n-portrait.webp" />	
+							<img alt="Midjourney generated image of Anthony Bourdain in Nashville" class="h-full w-full object-cover" src="/no-reserv-ai-tions/ai-nthony-bourd-ai-n-portrait.webp" />
 						</li>
 						{reviews.map((review) => (
 							<li class="min-h-[80dvh] overflow-hidden relative">
-								<a class="absolute bottom-0 left-0 right-0 top-16 block duration-300 group isolate  transition-all sm:mt-0  hover:bg-red-700 dark:hover:bg-slate-800" href={`/no-reserv-ai-tions/${review.slug}/`}>
-									<img class="absolute h-full inset-x-2/4	max-w-[unset] top-0 -translate-x-2/4	" src={`/no-reserv-ai-tions/${review.data.heroImage}.webp`} alt={review.data.heroImageAlt} />
+								<a class="absolute inset-0 block duration-300 group isolate transition-all sm:mt-0 hover:bg-red-700 dark:hover:bg-slate-800" href={`/no-reserv-ai-tions/${review.slug}/`}>
+									<img class="h-full w-full object-cover" src={`/no-reserv-ai-tions/${review.data.heroImage}.webp`} alt={review.data.heroImageAlt} />
 								</a>
 							</li>
 						))}

--- a/src/pages/no-reserv-ai-tions/states/index.astro
+++ b/src/pages/no-reserv-ai-tions/states/index.astro
@@ -8,34 +8,101 @@ import { ViewTransitions } from 'astro:transitions';
 export const prerender = true;
 
 const allReviews = await Astro.glob('../../../content/reviews/*.md');
-const states = [...new Set(allReviews.map((review) => review.frontmatter.state).flat())].filter(state => state !== '').sort();
 
+// Build state data: name, review count, representative image, and cities
+const stateMap = new Map();
+for (const review of allReviews) {
+	const stateKey = String(review.frontmatter.state).toLowerCase();
+	if (!stateKey || stateKey === '') continue;
+	if (!stateMap.has(stateKey)) {
+		stateMap.set(stateKey, {
+			name: stateKey,
+			count: 0,
+			image: review.frontmatter.heroImage,
+			imageAlt: review.frontmatter.heroImageAlt,
+			cities: new Set(),
+		});
+	}
+	const entry = stateMap.get(stateKey);
+	entry.count++;
+	const city = String(review.frontmatter.city).toLowerCase();
+	if (city) entry.cities.add(city);
+}
+
+const states = [...stateMap.values()].sort((a, b) => b.count - a.count);
 ---
 <!doctype html>
 <html lang="en">
 	<head>
-		<BaseHead title="No ReservAItions Cities | Dan Denney" description="Reviews of food, music, and events with the help of AI" />
+		<BaseHead title="No ReservAItions States | Dan Denney" description="Reviews of food, music, and events with the help of AI" />
 		<ViewTransitions />
+		<style>
+			.state-card {
+				transition: transform 0.3s ease, box-shadow 0.3s ease;
+			}
+			.state-card:hover {
+				transform: translateY(-4px);
+				box-shadow: 0 12px 32px rgba(0, 0, 0, 0.3);
+			}
+			.state-card:hover img {
+				transform: scale(1.08);
+			}
+			.state-card img {
+				transition: transform 0.6s ease;
+			}
+			.state-card:hover .state-overlay {
+				background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
+			}
+			.state-overlay {
+				background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.1) 50%, transparent 100%);
+				transition: background 0.3s ease;
+			}
+		</style>
 	</head>
 	<body class="bg-slate-50 dark:bg-slate-900">
 		<Header />
-		<main class="bg-slate-50 relative shadow-xs z-10 xl:flex dark:bg-slate-900 dark:text-slate-200" style="min-height: 90dvh;">  
-      <section class="max-w-(--breakpoint-xl) mx-auto pb-24 pt-8 px-4">
-				<h2 class="border-b text-center text-4xl font-bold pb-4 tracking-tight text-gray-900 dark:text-slate-100 md:shrink-0 md:text-left xl:border-0 xl:text-6xl">
-          States
-        </h2>
-        <p class="mt-2 text-gray-600 dark:text-slate-100">
-          States with reviews of food, music, and events with the help of AI
-        </p>
-        <nav class="has-links flex flex-wrap items-start mt-8 gap-x-8 gap-y-4 xl:gap-x-12 xl:gap-y-8">
-          {states.map((state) => (
-            <a class="md:text-2xl xl:text-6xl" href={`/no-reserv-ai-tions/states/${state}`}>
-              {toTitleCase(state)}
-            </a>
-          ))}
-        </nav>
-      </section>
-    </main>
-    <Footer />
-  </body>
+		<main class="bg-slate-50 relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200" style="min-height: 90dvh;">
+			<section class="mx-auto pb-24 pt-8 px-4 max-w-(--breakpoint-2xl)">
+				<div class="mb-8">
+					<h2 class="text-4xl font-bold tracking-tight text-gray-900 dark:text-slate-100 xl:text-6xl">States</h2>
+					<p class="mt-2 text-gray-600 dark:text-slate-300">
+						<span class="whitespace-nowrap">[&nbsp;{states.length} states, {allReviews.filter(r => String(r.frontmatter.state).toLowerCase() !== '').length} reviews&nbsp;]</span>
+					</p>
+				</div>
+
+				<nav class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+					{states.map((state, i) => (
+						<a
+							href={`/no-reserv-ai-tions/states/${state.name}`}
+							class:list={[
+								"state-card relative block overflow-hidden rounded-lg",
+								i === 0 ? "aspect-[16/9] sm:col-span-2 lg:col-span-2" : "aspect-[4/3]",
+							]}
+						>
+							<img
+								src={`/no-reserv-ai-tions/${state.image}.webp`}
+								alt={state.imageAlt}
+								class="absolute inset-0 h-full w-full object-cover"
+								loading={i < 4 ? "eager" : "lazy"}
+							/>
+							<div class="state-overlay absolute inset-0 flex flex-col justify-end p-5 lg:p-8">
+								<h3 class="text-2xl font-bold text-white leading-tight lg:text-3xl xl:text-4xl">
+									{toTitleCase(state.name)}
+								</h3>
+								<div class="flex flex-wrap items-center gap-2 mt-2">
+									<span class="inline-block rounded-full bg-white/20 px-3 py-1 text-sm text-white backdrop-blur-sm">
+										{state.count} {state.count === 1 ? 'review' : 'reviews'}
+									</span>
+									<span class="inline-block rounded-full bg-white/20 px-3 py-1 text-sm text-white backdrop-blur-sm">
+										{state.cities.size} {state.cities.size === 1 ? 'city' : 'cities'}
+									</span>
+								</div>
+							</div>
+						</a>
+					))}
+				</nav>
+			</section>
+		</main>
+		<Footer />
+	</body>
 </html>

--- a/src/pages/no-reserv-ai-tions/tags.astro
+++ b/src/pages/no-reserv-ai-tions/tags.astro
@@ -8,28 +8,117 @@ import { ViewTransitions } from 'astro:transitions';
 export const prerender = true;
 
 const allReviews = await Astro.glob('../../content/reviews/*.md');
-const tags = [...new Set(allReviews.map((review) => review.frontmatter.tags).flat())].sort();
 
+// Build tag data: name, count, and a representative image
+const tagMap = new Map();
+for (const review of allReviews) {
+	const tags = review.frontmatter.tags || [];
+	for (const tag of tags) {
+		const tagKey = String(tag).toLowerCase();
+		if (!tagMap.has(tagKey)) {
+			tagMap.set(tagKey, {
+				name: tagKey,
+				count: 0,
+				image: review.frontmatter.heroImage,
+				imageAlt: review.frontmatter.heroImageAlt,
+			});
+		}
+		tagMap.get(tagKey).count++;
+	}
+}
+
+const tags = [...tagMap.values()].sort((a, b) => b.count - a.count);
+const maxCount = tags[0]?.count || 1;
 ---
 <!doctype html>
 <html lang="en">
 	<head>
 		<BaseHead title="No ReservAItions Tags | Dan Denney" description="Reviews of food, music, and events with the help of AI" />
 		<ViewTransitions />
+		<style>
+			.tag-card {
+				transition: transform 0.3s ease, box-shadow 0.3s ease;
+			}
+			.tag-card:hover {
+				transform: translateY(-4px);
+				box-shadow: 0 12px 32px rgba(0, 0, 0, 0.3);
+			}
+			.tag-card:hover img {
+				transform: scale(1.08);
+			}
+			.tag-card img {
+				transition: transform 0.6s ease;
+			}
+			.tag-card:hover .tag-overlay {
+				background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
+			}
+			.tag-overlay {
+				background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.1) 50%, transparent 100%);
+				transition: background 0.3s ease;
+			}
+		</style>
 	</head>
 	<body class="bg-slate-50 dark:bg-slate-900">
 		<Header />
-		<main class="bg-slate-50 dark:bg-slate-900 relative shadow-xs z-10 dark:text-slate-200" style="min-height: 90dvh;">
-			<section class="max-w-(--breakpoint-xl) mx-auto pb-24 pt-8 px-4">
-				<h2 class="border-b text-center text-4xl font-bold pb-4 tracking-tight text-gray-900 dark:text-slate-100 md:shrink-0 md:text-left xl:border-0 xl:text-6xl">No ReservAItions Tags</h2>
-        <p class="mt-2 text-gray-600 dark:text-slate-100">Tagged reviews of food, music, and events with the help of AI</p>
-        <nav class="has-links flex flex-wrap items-start mt-8 gap-x-8 gap-y-4 xl:gap-x-12 xl:gap-y-8">
-          {tags.map((tag) => (
-            <a class="md:text-2xl xl:text-4xl" href={`/no-reserv-ai-tions/${tag}`}>{toTitleCase(tag)}</a>
-          ))}
-        </nav>
-      </section>
-    </main>
-    <Footer />
-  </body>
+		<main class="bg-slate-50 relative shadow-xs z-10 dark:bg-slate-900 dark:text-slate-200" style="min-height: 90dvh;">
+			<section class="mx-auto pb-24 pt-8 px-4 max-w-(--breakpoint-2xl)">
+				<div class="mb-8">
+					<h2 class="text-4xl font-bold tracking-tight text-gray-900 dark:text-slate-100 xl:text-6xl">Tags</h2>
+					<p class="mt-2 text-gray-600 dark:text-slate-300">
+						<span class="whitespace-nowrap">[&nbsp;{tags.length} tags across {allReviews.length} reviews&nbsp;]</span>
+					</p>
+				</div>
+
+				<!-- Top tags as image cards -->
+				<div class="grid grid-cols-2 gap-3 md:grid-cols-4 lg:grid-cols-6 xl:gap-4">
+					{tags.slice(0, 12).map((tag, i) => (
+						<a
+							href={`/no-reserv-ai-tions/${tag.name}`}
+							class:list={[
+								"tag-card relative block overflow-hidden rounded-lg aspect-square",
+								i < 2 ? "col-span-2 row-span-2 md:col-span-2 md:row-span-2" : "",
+							]}
+						>
+							<img
+								src={`/no-reserv-ai-tions/${tag.image}.webp`}
+								alt={tag.imageAlt}
+								class="absolute inset-0 h-full w-full object-cover"
+								loading="eager"
+							/>
+							<div class="tag-overlay absolute inset-0 flex flex-col justify-end p-4 lg:p-5">
+								<h3 class="text-lg font-bold text-white leading-tight lg:text-xl">
+									{toTitleCase(tag.name)}
+								</h3>
+								<span class="mt-1 inline-block w-fit rounded-full bg-white/20 px-2 py-0.5 text-xs text-white backdrop-blur-sm">
+									{tag.count}
+								</span>
+							</div>
+						</a>
+					))}
+				</div>
+
+				<!-- Remaining tags -->
+				{tags.length > 12 && (
+					<div class="mt-12">
+						<h3 class="text-lg font-semibold text-gray-700 dark:text-slate-300 mb-4">All Tags</h3>
+						<nav class="has-links flex flex-wrap gap-x-6 gap-y-3">
+							{tags.slice(12).map((tag) => {
+								const ratio = tag.count / maxCount;
+								const size = ratio > 0.3 ? 'text-xl' : ratio > 0.15 ? 'text-base' : 'text-sm';
+								return (
+									<a
+										href={`/no-reserv-ai-tions/${tag.name}`}
+										class={size}
+									>
+										{toTitleCase(tag.name)} <span class="text-gray-400 dark:text-slate-500 text-xs">[&nbsp;{tag.count}&nbsp;]</span>
+									</a>
+								);
+							})}
+						</nav>
+					</div>
+				)}
+			</section>
+		</main>
+		<Footer />
+	</body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -112,8 +112,8 @@
 
 /* Links */
 
-.longform a,
-.has-links a {
+.longform a:not(.btn-link),
+.has-links a:not(.btn-link) {
   @apply bg-no-repeat font-semibold no-underline text-red-700;
   background-image: linear-gradient(
     to bottom,
@@ -124,8 +124,8 @@
   transition: background-size 0.4s ease;
 }
 
-.dark .longform a,
-.dark .has-links a {
+.dark .longform a:not(.btn-link),
+.dark .has-links a:not(.btn-link) {
   @apply bg-no-repeat font-semibold no-underline text-red-300;
   background-image: linear-gradient(
     to bottom,
@@ -498,6 +498,10 @@
     margin-right: -12.5%;
     transform: none;
   }
+}
+
+.review img {
+  border-radius: 0.5rem;
 }
 
 /* Generated Images */


### PR DESCRIPTION
## Summary

Complete visual redesign of the No ReservAItions section with full-width layouts, improved visual hierarchy, and consistent design language across all pages:

- **Root page**: Removed max-width constraint for full-width two-column grid layout
- **Cities page**: New visual grid with image cards sorted by review count, top city featured larger
- **States page**: Image card grid with review and city count badges
- **Tags page**: Top 12 tags as image cards, remainder as brand-consistent styled links  
- **Review layout**: Complete restructure with centered title section, hero image layered above white card

## Key Changes

### Layout & Structure
- Root page now spans full browser width with `lg:grid lg:grid-cols-2` instead of `max-w-(--breakpoint-xl)`
- Review layout completely restructured: centered gray title section + layered hero image + white content card
- All pages now use consistent image card patterns with dark overlay gradients

### Visual Design
- Image cards display location, counts, and metadata with [ ] bracket notation
- Full-resolution images throughout (instead of thumbnails)
- Dark gradient overlays on images for text readability
- Proper layering with absolute positioning to eliminate visual gaps

### Typography & Spacing
- Added \`text-balance\` to headings for improved line breaks
- Reduced spacing between hero image and content (pt-4 lg:pt-6)
- Consistent padding and gap values across all pages

### Features
- Parallax scroll effect on review hero images (\`yPercent: -8\`)
- Responsive grid layouts with proper aspect ratios
- Dark mode support on all redesigned pages
- Hover states with image zoom and enhanced shadows

## Test Plan

- [ ] Root page displays full width on desktop without scrollbar changes
- [ ] Scroll trigger animations work on root page (images shift with scroll)
- [ ] Cities page displays correct image card grid with top city larger
- [ ] States page shows both review and city count badges
- [ ] Tags page shows top 12 as image cards, remainder as styled links
- [ ] Review page title/metadata centered on gray background
- [ ] Review hero image overlaps white card without visible gap
- [ ] Review page has border-bottom separating from footer
- [ ] All pages support dark mode correctly
- [ ] Mobile responsive layouts work across breakpoints
- [ ] Link hover states match site brand (red underline for has-links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)