### PR TITLE
feat: add scroll-reactive No ReservAItions gallery page

### DIFF
--- a/src/pages/no-reserv-ai-tions/index.astro
+++ b/src/pages/no-reserv-ai-tions/index.astro
@@ -92,7 +92,7 @@ const reviews = (await getCollection('reviews')).sort(
 						</h1>
 						<p class="mt-8 max-w-3xl text-gray-600 dark:text-slate-100"><a href="https://en.wikipedia.org/wiki/Anthony_Bourdain">Anthony Bourdain</a> had a glorious way of describing the human experience, especially when it revolved around food and drink. This project uses AI to write reviews of places, in his general style. No bot can compare to the real person, but <strong class="font-bold">AI</strong>nthony Bourd<strong class="font-bold">AI</strong>n sure can bring life to a description of a place or an experience.</p>
 
-						<p class="has-links mt-8">See them all by <a href="/no-reserv-ai-tions/1">newest</a>, <a href="/no-reserv-ai-tions/cities">city</a>, <a href="/no-reserv-ai-tions/states">state</a>, or by <a href="/no-reserv-ai-tions/tags">tag</a></p>
+						<p class="has-links mt-8">See them all by <a href="/no-reserv-ai-tions/1">newest</a>, <a href="/no-reserv-ai-tions/cities">city</a>, <a href="/no-reserv-ai-tions/states">state</a>, or by <a href="/no-reserv-ai-tions/tags">tag</a>. Want the immersive version? Try the <a href="/no-reserv-ai-tions/scroll-gallery">scroll gallery</a>.</p>
 
 						<h2 class="text-4xl font-bold mt-16 tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100 md:shrink-0">Latest Reviews</h2>
 

--- a/src/pages/no-reserv-ai-tions/scroll-gallery.astro
+++ b/src/pages/no-reserv-ai-tions/scroll-gallery.astro
@@ -1,0 +1,379 @@
+---
+import BaseHead from '../../components/BaseHead.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { getCollection } from 'astro:content';
+
+export const prerender = true;
+
+const reviews = (await getCollection('reviews'))
+  .filter((review) => review.data.heroImage)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 8)
+  .map((review) => ({
+    slug: review.slug,
+    title: review.data.title,
+    description: review.data.description,
+    city: review.data.city,
+    state: review.data.state,
+    country: review.data.country,
+    heroImage: review.data.heroImage,
+    heroImageAlt: review.data.heroImageAlt ?? `Photo from ${review.data.title}`,
+    pubDate: review.data.pubDate.toISOString(),
+  }));
+
+const reviewPayload = JSON.stringify(reviews);
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title="No ReservAItions Scroll Gallery"
+      description="An experimental scroll-reactive No ReservAItions gallery with graceful motion and rendering fallbacks."
+    />
+    <style>
+      .nra-wrap {
+        --bg-1: #0f172a;
+        --bg-2: #312e81;
+        --bg-3: #0b1020;
+        min-height: 100dvh;
+        background: radial-gradient(1200px 700px at 20% 20%, var(--bg-2), transparent 65%),
+          radial-gradient(1000px 600px at 80% 80%, #7f1d1d55, transparent 65%),
+          linear-gradient(145deg, var(--bg-1), var(--bg-3));
+        color: #f8fafc;
+      }
+
+      .nra-shell {
+        width: min(1100px, 92vw);
+        margin: 0 auto;
+        padding: 2rem 0 6rem;
+      }
+
+      .nra-heading {
+        max-width: 65ch;
+      }
+
+      .nra-heading h1 {
+        font-size: clamp(2rem, 4vw, 3rem);
+        line-height: 1.1;
+        margin-bottom: 1rem;
+      }
+
+      .nra-heading p {
+        color: #cbd5e1;
+      }
+
+      .nra-viewport {
+        position: sticky;
+        top: 1.2rem;
+        height: min(72dvh, 640px);
+        margin: 2rem 0;
+        border-radius: 1.25rem;
+        overflow: hidden;
+        border: 1px solid #ffffff22;
+        background: #02061766;
+        box-shadow: 0 18px 60px #00000066;
+      }
+
+      .nra-canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .nra-track {
+        position: relative;
+      }
+
+      .nra-step {
+        min-height: 74dvh;
+        padding: 2rem 0;
+        display: grid;
+        align-items: center;
+      }
+
+      .nra-step-card {
+        max-width: 40rem;
+        border-radius: 1rem;
+        border: 1px solid #ffffff20;
+        background: #020617b0;
+        backdrop-filter: blur(8px);
+        padding: 1.25rem;
+      }
+
+      .nra-step h2 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(1.3rem, 2.6vw, 2rem);
+      }
+
+      .nra-step p {
+        margin: 0.5rem 0;
+        color: #dbeafe;
+      }
+
+      .nra-meta {
+        color: #93c5fd;
+        font-size: 0.9rem;
+      }
+
+      .nra-link {
+        display: inline-block;
+        margin-top: 0.75rem;
+        color: #fca5a5;
+      }
+
+      .nra-fallback {
+        margin-top: 1rem;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+      }
+
+      .nra-fallback[hidden] { display: none; }
+
+      .nra-fallback img {
+        border-radius: 0.75rem;
+        width: 100%;
+        aspect-ratio: 4/3;
+        object-fit: cover;
+      }
+
+      @media (max-width: 900px) {
+        .nra-viewport {
+          position: relative;
+          top: auto;
+          height: 48dvh;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .nra-viewport { display: none; }
+        .nra-step { min-height: auto; padding: 1.25rem 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <Header />
+    <main class="nra-wrap">
+      <div class="nra-shell">
+        <div class="nra-heading">
+          <h1>No ReservAItions: Scroll Gallery</h1>
+          <p>
+            A scroll-reactive experiment inspired by modern 3D gallery motion. This version keeps it production-safe:
+            no external animation libraries, reduced-motion support, and a static fallback if canvas/web APIs are unavailable.
+          </p>
+          <p><a class="nra-link" href="/no-reserv-ai-tions">← Back to No ReservAItions</a></p>
+        </div>
+
+        <section class="nra-viewport" aria-hidden="true">
+          <canvas id="nra-canvas" class="nra-canvas"></canvas>
+        </section>
+
+        <section id="nra-fallback" class="nra-fallback" hidden>
+          {reviews.map((review) => (
+            <article class="nra-step-card">
+              <img src={`/no-reserv-ai-tions/${review.heroImage}.webp`} alt={review.heroImageAlt} loading="lazy" decoding="async" />
+              <h2>{review.title}</h2>
+              <p>{review.description}</p>
+              <a class="nra-link" href={`/no-reserv-ai-tions/${review.slug}`}>Read full review</a>
+            </article>
+          ))}
+        </section>
+
+        <section class="nra-track" aria-label="Scroll through featured reviews">
+          {reviews.map((review, index) => (
+            <article class="nra-step" data-index={index}>
+              <div class="nra-step-card">
+                <p class="nra-meta">
+                  {review.city}{review.state ? `, ${review.state}` : ''}{review.country !== 'United States' ? `, ${review.country}` : ''}
+                </p>
+                <h2>{review.title}</h2>
+                <p>{review.description}</p>
+                <a class="nra-link" href={`/no-reserv-ai-tions/${review.slug}`}>Read full review</a>
+              </div>
+            </article>
+          ))}
+        </section>
+      </div>
+    </main>
+    <Footer />
+
+    <script is:inline define:vars={{ reviewPayload }}>
+      const initScrollGallery = () => {
+        if (window.__nraScrollGalleryInit) return;
+        window.__nraScrollGalleryInit = true;
+
+        const reviews = JSON.parse(reviewPayload);
+        const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const canvas = document.getElementById('nra-canvas');
+        const fallback = document.getElementById('nra-fallback');
+        const steps = Array.from(document.querySelectorAll('.nra-step'));
+
+        if (prefersReduced || !canvas || !canvas.getContext || !('IntersectionObserver' in window)) {
+          fallback?.removeAttribute('hidden');
+          return;
+        }
+
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          fallback?.removeAttribute('hidden');
+          return;
+        }
+
+        const DPR_CAP = 1.75;
+        const images = reviews.map((item) => {
+          const img = new Image();
+          img.src = `/no-reserv-ai-tions/${item.heroImage}.webp`;
+          img.loading = 'eager';
+          img.decoding = 'async';
+          return img;
+        });
+
+        let activeIndex = 0;
+        let progress = 0;
+        let targetProgress = 0;
+        let mood = 0;
+        let lastScrollY = window.scrollY;
+        let velocity = 0;
+        let raf = null;
+
+        const resize = () => {
+          const dpr = Math.min(window.devicePixelRatio || 1, DPR_CAP);
+          const bounds = canvas.getBoundingClientRect();
+          canvas.width = Math.max(1, Math.floor(bounds.width * dpr));
+          canvas.height = Math.max(1, Math.floor(bounds.height * dpr));
+          ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        };
+
+        const drawCard = (img, idx) => {
+          const w = canvas.clientWidth;
+          const h = canvas.clientHeight;
+          const centerX = w * 0.5;
+          const centerY = h * 0.5;
+          const depth = idx - activeIndex - progress;
+          const z = Math.max(-1.5, Math.min(1.5, depth));
+          const scale = 1 - Math.abs(z) * 0.18;
+          const y = centerY + z * 120;
+          const x = centerX + z * 80;
+
+          const cardW = Math.min(560, w * 0.72) * scale;
+          const cardH = cardW * 0.68;
+          const tilt = z * 0.08 + velocity * 0.0015;
+
+          ctx.save();
+          ctx.translate(x, y);
+          ctx.rotate(tilt);
+          ctx.globalAlpha = Math.max(0, 1 - Math.abs(z) * 0.45);
+
+          ctx.fillStyle = '#020617ee';
+          ctx.strokeStyle = '#ffffff22';
+          ctx.lineWidth = 1;
+          const left = -cardW / 2;
+          const top = -cardH / 2;
+          const radius = 16;
+
+          ctx.beginPath();
+          ctx.moveTo(left + radius, top);
+          ctx.arcTo(left + cardW, top, left + cardW, top + cardH, radius);
+          ctx.arcTo(left + cardW, top + cardH, left, top + cardH, radius);
+          ctx.arcTo(left, top + cardH, left, top, radius);
+          ctx.arcTo(left, top, left + cardW, top, radius);
+          ctx.closePath();
+          ctx.fill();
+          ctx.stroke();
+
+          if (img && img.complete) {
+            const pad = 14;
+            const drawW = cardW - pad * 2;
+            const drawH = cardH - pad * 2;
+            ctx.save();
+            ctx.beginPath();
+            ctx.rect(left + pad, top + pad, drawW, drawH);
+            ctx.clip();
+
+            const imageRatio = img.naturalWidth / img.naturalHeight;
+            const cardRatio = drawW / drawH;
+            let sx = 0, sy = 0, sw = img.naturalWidth, sh = img.naturalHeight;
+
+            if (imageRatio > cardRatio) {
+              sw = img.naturalHeight * cardRatio;
+              sx = (img.naturalWidth - sw) / 2;
+            } else {
+              sh = img.naturalWidth / cardRatio;
+              sy = (img.naturalHeight - sh) / 2;
+            }
+
+            ctx.drawImage(img, sx, sy, sw, sh, left + pad, top + pad, drawW, drawH);
+            ctx.restore();
+          }
+
+          if (Math.abs(z) < 0.55) {
+            const text = reviews[idx].title;
+            ctx.fillStyle = '#f8fafc';
+            ctx.font = '600 22px Inter, system-ui, sans-serif';
+            ctx.fillText(text, left + 24, top + cardH - 24);
+          }
+
+          ctx.restore();
+        };
+
+        const render = () => {
+          const w = canvas.clientWidth;
+          const h = canvas.clientHeight;
+          progress += (targetProgress - progress) * 0.12;
+          velocity = (window.scrollY - lastScrollY) * 0.85 + velocity * 0.15;
+          lastScrollY = window.scrollY;
+          mood += (Math.min(1, Math.abs(velocity) / 70) - mood) * 0.06;
+
+          const r = Math.floor(15 + mood * 24);
+          const g = Math.floor(23 + mood * 8);
+          const b = Math.floor(42 + mood * 30);
+          const grad = ctx.createLinearGradient(0, 0, w, h);
+          grad.addColorStop(0, `rgb(${r},${g},${b})`);
+          grad.addColorStop(1, `rgb(${10 + Math.floor(mood * 28)}, 16, ${30 + Math.floor(mood * 20)})`);
+          ctx.fillStyle = grad;
+          ctx.fillRect(0, 0, w, h);
+
+          for (let i = reviews.length - 1; i >= 0; i--) {
+            drawCard(images[i], i, progress);
+          }
+
+          raf = requestAnimationFrame(render);
+        };
+
+        const observer = new IntersectionObserver((entries) => {
+          entries.forEach((entry) => {
+            if (!entry.isIntersecting) return;
+            const idx = Number(entry.target.getAttribute('data-index') || 0);
+            activeIndex = idx;
+          });
+        }, { threshold: 0.6 });
+
+        steps.forEach((step) => observer.observe(step));
+
+        const onScroll = () => {
+          const current = steps[activeIndex];
+          if (!current) return;
+          const rect = current.getBoundingClientRect();
+          targetProgress = Math.max(-1, Math.min(1, (window.innerHeight * 0.5 - rect.top) / Math.max(rect.height, 1)));
+        };
+
+        resize();
+        onScroll();
+        render();
+
+        window.addEventListener('resize', resize, { passive: true });
+        window.addEventListener('scroll', onScroll, { passive: true });
+
+        window.addEventListener('beforeunload', () => {
+          observer.disconnect();
+          if (raf) cancelAnimationFrame(raf);
+        }, { once: true });
+      };
+
+      document.addEventListener('astro:page-load', initScrollGallery, { once: true });
+      if (document.readyState !== 'loading') initScrollGallery();
+    </script>
+  </body>
+</html>

--- a/src/pages/no-reserv-ai-tions/scroll-gallery.astro
+++ b/src/pages/no-reserv-ai-tions/scroll-gallery.astro
@@ -42,6 +42,7 @@ const reviewPayload = JSON.stringify(reviews);
           radial-gradient(1000px 600px at 80% 80%, #7f1d1d55, transparent 65%),
           linear-gradient(145deg, var(--bg-1), var(--bg-3));
         color: #f8fafc;
+        transition: background 260ms ease;
       }
 
       .nra-shell {
@@ -100,6 +101,16 @@ const reviewPayload = JSON.stringify(reviews);
         background: #020617b0;
         backdrop-filter: blur(8px);
         padding: 1.25rem;
+        transform: translateY(16px) scale(0.98);
+        opacity: 0.72;
+        transition: transform 260ms ease, opacity 260ms ease, border-color 260ms ease, box-shadow 260ms ease;
+      }
+
+      .nra-step.is-active .nra-step-card {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+        border-color: #c7d2fe66;
+        box-shadow: 0 16px 36px #02061766;
       }
 
       .nra-step h2 {
@@ -150,12 +161,19 @@ const reviewPayload = JSON.stringify(reviews);
       @media (prefers-reduced-motion: reduce) {
         .nra-viewport { display: none; }
         .nra-step { min-height: auto; padding: 1.25rem 0; }
+        .nra-step-card,
+        .nra-step.is-active .nra-step-card {
+          transition: none;
+          transform: none;
+          opacity: 1;
+          box-shadow: none;
+        }
       }
     </style>
   </head>
   <body>
     <Header />
-    <main class="nra-wrap">
+    <main class="nra-wrap" id="nra-wrap">
       <div class="nra-shell">
         <div class="nra-heading">
           <h1>No ReservAItions: Scroll Gallery</h1>
@@ -166,7 +184,7 @@ const reviewPayload = JSON.stringify(reviews);
           <p><a class="nra-link" href="/no-reserv-ai-tions">← Back to No ReservAItions</a></p>
         </div>
 
-        <section class="nra-viewport" aria-hidden="true">
+        <section class="nra-viewport" id="nra-viewport" aria-hidden="true">
           <canvas id="nra-canvas" class="nra-canvas"></canvas>
         </section>
 
@@ -208,6 +226,8 @@ const reviewPayload = JSON.stringify(reviews);
         const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         const canvas = document.getElementById('nra-canvas');
         const fallback = document.getElementById('nra-fallback');
+        const viewport = document.getElementById('nra-viewport');
+        const wrap = document.getElementById('nra-wrap');
         const steps = Array.from(document.querySelectorAll('.nra-step'));
 
         if (prefersReduced || !canvas || !canvas.getContext || !('IntersectionObserver' in window)) {
@@ -216,12 +236,29 @@ const reviewPayload = JSON.stringify(reviews);
         }
 
         const ctx = canvas.getContext('2d');
-        if (!ctx) {
+        if (!ctx || !viewport || !wrap) {
           fallback?.removeAttribute('hidden');
           return;
         }
 
-        const DPR_CAP = 1.75;
+        const DPR_CAP = 1.7;
+        const CARD_RADIUS = 16;
+        const pointer = { x: 0, y: 0, tx: 0, ty: 0 };
+        const motion = {
+          activeIndex: 0,
+          progress: 0,
+          targetProgress: 0,
+          mood: 0,
+          velocity: 0,
+          lastScrollY: window.scrollY,
+          lastScrollT: performance.now(),
+          raf: 0,
+          running: false,
+          isVisible: true,
+          isInViewport: true,
+          lastWrapMoodSet: -1,
+        };
+
         const images = reviews.map((item) => {
           const img = new Image();
           img.src = `/no-reserv-ai-tions/${item.heroImage}.webp`;
@@ -230,60 +267,84 @@ const reviewPayload = JSON.stringify(reviews);
           return img;
         });
 
-        let activeIndex = 0;
-        let progress = 0;
-        let targetProgress = 0;
-        let mood = 0;
-        let lastScrollY = window.scrollY;
-        let velocity = 0;
-        let raf = null;
+        const clamp = (n, min, max) => Math.min(max, Math.max(min, n));
+
+        const setActiveStep = (idx) => {
+          for (let i = 0; i < steps.length; i += 1) {
+            const isActive = i === idx;
+            steps[i].classList.toggle('is-active', isActive);
+            if (isActive) steps[i].setAttribute('aria-current', 'true');
+            else steps[i].removeAttribute('aria-current');
+          }
+        };
 
         const resize = () => {
           const dpr = Math.min(window.devicePixelRatio || 1, DPR_CAP);
           const bounds = canvas.getBoundingClientRect();
-          canvas.width = Math.max(1, Math.floor(bounds.width * dpr));
-          canvas.height = Math.max(1, Math.floor(bounds.height * dpr));
+          const width = Math.max(1, Math.floor(bounds.width * dpr));
+          const height = Math.max(1, Math.floor(bounds.height * dpr));
+          if (canvas.width !== width || canvas.height !== height) {
+            canvas.width = width;
+            canvas.height = height;
+          }
           ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        };
+
+        const updatePointer = (clientX, clientY) => {
+          const rect = canvas.getBoundingClientRect();
+          if (!rect.width || !rect.height) return;
+          pointer.tx = clamp(((clientX - rect.left) / rect.width - 0.5) * 2, -1, 1);
+          pointer.ty = clamp(((clientY - rect.top) / rect.height - 0.5) * 2, -1, 1);
+        };
+
+        const drawRoundedCard = (left, top, width, height) => {
+          ctx.beginPath();
+          ctx.moveTo(left + CARD_RADIUS, top);
+          ctx.arcTo(left + width, top, left + width, top + height, CARD_RADIUS);
+          ctx.arcTo(left + width, top + height, left, top + height, CARD_RADIUS);
+          ctx.arcTo(left, top + height, left, top, CARD_RADIUS);
+          ctx.arcTo(left, top, left + width, top, CARD_RADIUS);
+          ctx.closePath();
         };
 
         const drawCard = (img, idx) => {
           const w = canvas.clientWidth;
           const h = canvas.clientHeight;
           const centerX = w * 0.5;
-          const centerY = h * 0.5;
-          const depth = idx - activeIndex - progress;
-          const z = Math.max(-1.5, Math.min(1.5, depth));
-          const scale = 1 - Math.abs(z) * 0.18;
-          const y = centerY + z * 120;
-          const x = centerX + z * 80;
+          const centerY = h * 0.52;
+          const depth = idx - motion.activeIndex - motion.progress;
+          const z = clamp(depth, -1.6, 1.6);
 
-          const cardW = Math.min(560, w * 0.72) * scale;
-          const cardH = cardW * 0.68;
-          const tilt = z * 0.08 + velocity * 0.0015;
+          const focus = 1 - Math.min(1, Math.abs(z) / 1.6);
+          const velPush = clamp(motion.velocity / 650, -0.7, 0.7);
+          const parallaxX = pointer.x * (28 + focus * 22);
+          const parallaxY = pointer.y * (18 + focus * 16);
+          const x = centerX + z * 96 + parallaxX;
+          const y = centerY + z * 126 + parallaxY - velPush * 42;
+
+          const baseW = Math.min(620, w * 0.74);
+          const cardW = baseW * (0.78 + focus * 0.22);
+          const cardH = cardW * 0.66;
+
+          const tilt = z * 0.08 + pointer.x * 0.03 + velPush * 0.05;
+          const skewY = pointer.y * 0.025;
 
           ctx.save();
           ctx.translate(x, y);
+          ctx.transform(1, skewY, 0, 1, 0, 0);
           ctx.rotate(tilt);
-          ctx.globalAlpha = Math.max(0, 1 - Math.abs(z) * 0.45);
+          ctx.globalAlpha = clamp(0.22 + focus * 0.88, 0, 1);
 
-          ctx.fillStyle = '#020617ee';
-          ctx.strokeStyle = '#ffffff22';
-          ctx.lineWidth = 1;
           const left = -cardW / 2;
           const top = -cardH / 2;
-          const radius = 16;
-
-          ctx.beginPath();
-          ctx.moveTo(left + radius, top);
-          ctx.arcTo(left + cardW, top, left + cardW, top + cardH, radius);
-          ctx.arcTo(left + cardW, top + cardH, left, top + cardH, radius);
-          ctx.arcTo(left, top + cardH, left, top, radius);
-          ctx.arcTo(left, top, left + cardW, top, radius);
-          ctx.closePath();
+          drawRoundedCard(left, top, cardW, cardH);
+          ctx.fillStyle = `rgba(2, 6, 23, ${0.8 + focus * 0.18})`;
+          ctx.strokeStyle = `rgba(199, 210, 254, ${0.12 + focus * 0.24})`;
+          ctx.lineWidth = 1;
           ctx.fill();
           ctx.stroke();
 
-          if (img && img.complete) {
+          if (img && img.complete && img.naturalWidth > 0) {
             const pad = 14;
             const drawW = cardW - pad * 2;
             const drawH = cardH - pad * 2;
@@ -294,81 +355,173 @@ const reviewPayload = JSON.stringify(reviews);
 
             const imageRatio = img.naturalWidth / img.naturalHeight;
             const cardRatio = drawW / drawH;
-            let sx = 0, sy = 0, sw = img.naturalWidth, sh = img.naturalHeight;
+            let sx = 0;
+            let sy = 0;
+            let sw = img.naturalWidth;
+            let sh = img.naturalHeight;
 
             if (imageRatio > cardRatio) {
               sw = img.naturalHeight * cardRatio;
-              sx = (img.naturalWidth - sw) / 2;
+              sx = (img.naturalWidth - sw) * 0.5;
             } else {
               sh = img.naturalWidth / cardRatio;
-              sy = (img.naturalHeight - sh) / 2;
+              sy = (img.naturalHeight - sh) * 0.5;
             }
 
-            ctx.drawImage(img, sx, sy, sw, sh, left + pad, top + pad, drawW, drawH);
+            const wobbleX = pointer.x * 8 * focus;
+            const wobbleY = pointer.y * 6 * focus;
+            ctx.drawImage(img, sx, sy, sw, sh, left + pad - wobbleX, top + pad - wobbleY, drawW + wobbleX * 2, drawH + wobbleY * 2);
             ctx.restore();
           }
 
-          if (Math.abs(z) < 0.55) {
-            const text = reviews[idx].title;
+          if (focus > 0.62) {
             ctx.fillStyle = '#f8fafc';
             ctx.font = '600 22px Inter, system-ui, sans-serif';
-            ctx.fillText(text, left + 24, top + cardH - 24);
+            ctx.fillText(reviews[idx].title, left + 24, top + cardH - 22);
           }
 
           ctx.restore();
         };
 
         const render = () => {
+          motion.raf = 0;
+          if (!motion.running) return;
+
+          pointer.x += (pointer.tx - pointer.x) * 0.08;
+          pointer.y += (pointer.ty - pointer.y) * 0.08;
+          motion.progress += (motion.targetProgress - motion.progress) * 0.14;
+
+          const now = performance.now();
+          const dt = Math.max(8, now - motion.lastScrollT);
+          const dy = window.scrollY - motion.lastScrollY;
+          const instantVelocity = (dy / dt) * 16.67;
+          motion.velocity = motion.velocity * 0.82 + instantVelocity * 0.18;
+          motion.lastScrollY = window.scrollY;
+          motion.lastScrollT = now;
+
           const w = canvas.clientWidth;
           const h = canvas.clientHeight;
-          progress += (targetProgress - progress) * 0.12;
-          velocity = (window.scrollY - lastScrollY) * 0.85 + velocity * 0.15;
-          lastScrollY = window.scrollY;
-          mood += (Math.min(1, Math.abs(velocity) / 70) - mood) * 0.06;
+          const moodTarget = clamp(Math.abs(motion.velocity) / 55 + Math.abs(pointer.x) * 0.22, 0, 1);
+          motion.mood += (moodTarget - motion.mood) * 0.06;
 
-          const r = Math.floor(15 + mood * 24);
-          const g = Math.floor(23 + mood * 8);
-          const b = Math.floor(42 + mood * 30);
+          const r = Math.floor(14 + motion.mood * 40);
+          const g = Math.floor(22 + motion.mood * 14);
+          const b = Math.floor(38 + motion.mood * 52);
+          const br = Math.floor(8 + motion.mood * 18);
+          const bg = Math.floor(14 + motion.mood * 10);
+          const bb = Math.floor(26 + motion.mood * 32);
+
           const grad = ctx.createLinearGradient(0, 0, w, h);
-          grad.addColorStop(0, `rgb(${r},${g},${b})`);
-          grad.addColorStop(1, `rgb(${10 + Math.floor(mood * 28)}, 16, ${30 + Math.floor(mood * 20)})`);
+          grad.addColorStop(0, `rgb(${r}, ${g}, ${b})`);
+          grad.addColorStop(1, `rgb(${br}, ${bg}, ${bb})`);
           ctx.fillStyle = grad;
           ctx.fillRect(0, 0, w, h);
 
-          for (let i = reviews.length - 1; i >= 0; i--) {
-            drawCard(images[i], i, progress);
+          const auraX = w * (0.5 + pointer.x * 0.22);
+          const auraY = h * (0.45 + pointer.y * 0.18);
+          const auraR = Math.max(w, h) * (0.55 + motion.mood * 0.18);
+          const aura = ctx.createRadialGradient(auraX, auraY, 0, auraX, auraY, auraR);
+          aura.addColorStop(0, `rgba(248, 250, 252, ${0.06 + motion.mood * 0.12})`);
+          aura.addColorStop(1, 'rgba(248, 250, 252, 0)');
+          ctx.fillStyle = aura;
+          ctx.fillRect(0, 0, w, h);
+
+          for (let i = reviews.length - 1; i >= 0; i -= 1) drawCard(images[i], i);
+
+          const moodBucket = Math.round(motion.mood * 10);
+          if (moodBucket !== motion.lastWrapMoodSet) {
+            motion.lastWrapMoodSet = moodBucket;
+            const hueShift = Math.round(232 + moodBucket * 6);
+            wrap.style.setProperty('--bg-2', `hsl(${hueShift} 58% 34%)`);
+            wrap.style.setProperty('--bg-3', `hsl(${225 + moodBucket * 2} 45% 11%)`);
           }
 
-          raf = requestAnimationFrame(render);
+          if (motion.running) motion.raf = requestAnimationFrame(render);
         };
 
-        const observer = new IntersectionObserver((entries) => {
-          entries.forEach((entry) => {
-            if (!entry.isIntersecting) return;
-            const idx = Number(entry.target.getAttribute('data-index') || 0);
-            activeIndex = idx;
-          });
-        }, { threshold: 0.6 });
-
-        steps.forEach((step) => observer.observe(step));
+        const queueRender = () => {
+          if (!motion.running) return;
+          if (!motion.raf) motion.raf = requestAnimationFrame(render);
+        };
 
         const onScroll = () => {
-          const current = steps[activeIndex];
+          const current = steps[motion.activeIndex];
           if (!current) return;
           const rect = current.getBoundingClientRect();
-          targetProgress = Math.max(-1, Math.min(1, (window.innerHeight * 0.5 - rect.top) / Math.max(rect.height, 1)));
+          const half = window.innerHeight * 0.5;
+          motion.targetProgress = clamp((half - rect.top) / Math.max(rect.height, 1), -1, 1);
+          queueRender();
+        };
+
+        const setRunningState = () => {
+          const shouldRun = motion.isVisible && motion.isInViewport;
+          if (shouldRun === motion.running) return;
+          motion.running = shouldRun;
+          if (motion.running) {
+            motion.lastScrollY = window.scrollY;
+            motion.lastScrollT = performance.now();
+            queueRender();
+          } else if (motion.raf) {
+            cancelAnimationFrame(motion.raf);
+            motion.raf = 0;
+          }
+        };
+
+        const stepObserver = new IntersectionObserver((entries) => {
+          for (let i = 0; i < entries.length; i += 1) {
+            const entry = entries[i];
+            if (!entry.isIntersecting) continue;
+            const idx = Number(entry.target.getAttribute('data-index') || 0);
+            motion.activeIndex = idx;
+            setActiveStep(idx);
+            onScroll();
+            break;
+          }
+        }, { threshold: 0.62 });
+
+        const viewportObserver = new IntersectionObserver((entries) => {
+          motion.isInViewport = Boolean(entries[0]?.isIntersecting);
+          setRunningState();
+        }, { threshold: 0.05 });
+
+        const onVisibility = () => {
+          motion.isVisible = !document.hidden;
+          setRunningState();
+        };
+
+        const onPointerMove = (event) => {
+          updatePointer(event.clientX, event.clientY);
+          queueRender();
+        };
+
+        const onTouchMove = (event) => {
+          const touch = event.touches && event.touches[0];
+          if (!touch) return;
+          updatePointer(touch.clientX, touch.clientY);
+          queueRender();
         };
 
         resize();
+        setActiveStep(0);
         onScroll();
-        render();
+
+        for (let i = 0; i < steps.length; i += 1) stepObserver.observe(steps[i]);
+        viewportObserver.observe(viewport);
+
+        motion.isVisible = !document.hidden;
+        motion.isInViewport = true;
+        setRunningState();
 
         window.addEventListener('resize', resize, { passive: true });
         window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('pointermove', onPointerMove, { passive: true });
+        window.addEventListener('touchmove', onTouchMove, { passive: true });
+        document.addEventListener('visibilitychange', onVisibility, { passive: true });
 
         window.addEventListener('beforeunload', () => {
-          observer.disconnect();
-          if (raf) cancelAnimationFrame(raf);
+          stepObserver.disconnect();
+          viewportObserver.disconnect();
+          if (motion.raf) cancelAnimationFrame(motion.raf);
         }, { once: true });
       };
 


### PR DESCRIPTION
## Summary
- add a new standalone No ReservAItions route at `/no-reserv-ai-tions/scroll-gallery`
- render 8 existing review entries in a scroll-reactive canvas gallery inspired by the Codrops concept
- add reduced-motion and non-canvas fallbacks to ensure graceful degradation
- add a discoverable link from the existing No ReservAItions landing page

## Implementation notes
- no new npm dependencies were added
- effect uses native Canvas 2D + IntersectionObserver + requestAnimationFrame
- background color shifts based on scroll velocity to create subtle mood transitions

## Accessibility and performance safeguards
- respects `prefers-reduced-motion: reduce` and switches to static cards
- detects missing browser APIs/canvas support and shows non-animated fallback content
- caps canvas DPR for lower GPU/CPU pressure on high-density screens
- keeps animation lightweight (single canvas render loop, no heavy libs)

## Validation
- `yarn build` (passes)
- `yarn astro check` (fails due to pre-existing repo-wide type issues unrelated to this PR)
