### PR TITLE
feat: add Shipp MVP manual signal ingestion for capital game dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
 
+## Shipp MVP integration (capital game)
+
+See `docs/shipp-integration.md` for:
+- required env vars (`SHIPP_API_KEY`, `SHIPP_CONNECTION_ID` / `SHIPP_CONNECTION_IDS`)
+- manual fetch endpoint (`POST /api/shipp/fetch`)
+- normalized signal state location (`src/data/shipp-state.json`)
+
 ## 👀 Want to learn more?
 
 Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/docs/shipp-integration.md
+++ b/docs/shipp-integration.md
@@ -1,0 +1,62 @@
+# Shipp MVP Integration (Capital Game Dashboard)
+
+This project includes a server-side Shipp integration for manual signal ingestion.
+
+## 1) Add API key + connection IDs
+
+Add these values to `.env.local`:
+
+```bash
+SHIPP_API_KEY=your_real_shipp_api_key
+# one option:
+SHIPP_CONNECTION_ID=01ABC...
+# or multiple:
+SHIPP_CONNECTION_IDS=01ABC...,01DEF...
+```
+
+Notes:
+- `SHIPP_API_KEY` is required for live Shipp calls.
+- Signals are fetched server-side only (key is never exposed to browser code).
+
+## 2) Manual fetch trigger (safe / human-in-loop)
+
+### Live Shipp fetch
+
+```bash
+curl -sS -X POST http://localhost:4321/api/shipp/fetch \
+  -H 'Content-Type: application/json' \
+  -d '{"limit":100}'
+```
+
+### Local mock fetch (no API key required)
+
+```bash
+curl -sS -X POST http://localhost:4321/api/shipp/fetch \
+  -H 'Content-Type: application/json' \
+  -d '{"useMock":true}'
+```
+
+## 3) Read latest normalized signals
+
+```bash
+curl -sS http://localhost:4321/api/shipp/signals
+```
+
+Signals are also shown in `/capital-game-dashboard` under **Shipp Signal Feed (Debug)**.
+
+## 4) Persistence/state files
+
+State is stored in:
+
+- `src/data/shipp-state.json`
+
+It tracks:
+- per-connection `sinceEventId` cursor
+- last run/success/error metadata
+- `latestSignals` (normalized, deduped, capped)
+
+## 5) Non-breaking behavior
+
+- Dashboard keeps existing capital game logic intact.
+- Shipp section is read-only/debug-only.
+- No automatic bet placement is performed.

--- a/src/data/martingaleBets.ts
+++ b/src/data/martingaleBets.ts
@@ -92,6 +92,16 @@ export const martingaleBets: MartingaleBet[] = [
     returnAmount: 58.3,
     balanceImpact: 58.3,
   },
+  {
+    id: 6,
+    date: "2026-03-13",
+    seriesId: "D",
+    pick: "Scoot Henderson Over 4.5 Assists",
+    line: "+100",
+    amount: 30,
+    result: "pending",
+    stakeOut: 30,
+  },
 ];
 
 export const getStakeOut = (bet: MartingaleBet): number =>

--- a/src/data/shipp-state.json
+++ b/src/data/shipp-state.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "updatedAt": "2026-03-13T16:22:39.304Z",
+  "connections": {
+    "demo-conn": {
+      "sinceEventId": "mock-1773418959304",
+      "lastRunAt": "2026-03-13T16:22:39.304Z",
+      "lastSuccessAt": "2026-03-13T16:22:39.304Z",
+      "lastError": null
+    }
+  },
+  "latestSignals": [
+    {
+      "id": "demo-conn:mock-1773418959304:2026-03-13T16:22:39.304Z",
+      "connectionId": "demo-conn",
+      "eventCursor": "mock-1773418959304",
+      "gameId": "LAL-vs-BOS",
+      "sport": "nba",
+      "eventType": "score",
+      "description": "Mock signal for local integration validation",
+      "period": 3,
+      "gameClock": "04:12",
+      "home": "Lakers",
+      "away": "Celtics",
+      "homePoints": 92,
+      "awayPoints": 95,
+      "wallClockStart": "2026-03-13T16:22:39.304Z",
+      "wallClockEnd": null,
+      "receivedAt": "2026-03-13T16:22:39.304Z",
+      "raw": {
+        "attribution_id": "mock-1773418959304",
+        "game_id": "LAL-vs-BOS",
+        "sport": "nba",
+        "type": "score",
+        "desc": "Mock signal for local integration validation",
+        "game_period": 3,
+        "game_clock": "04:12",
+        "home": "Lakers",
+        "away": "Celtics",
+        "home_points": 92,
+        "away_points": 95,
+        "wall_clock_start": "2026-03-13T16:22:39.304Z"
+      }
+    }
+  ]
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,12 @@
 /// <reference types="astro/client" />
 /// <reference path="../.astro/types.d.ts" />
+
+interface ImportMetaEnv {
+  readonly SHIPP_API_KEY?: string;
+  readonly SHIPP_CONNECTION_ID?: string;
+  readonly SHIPP_CONNECTION_IDS?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/pages/api/shipp/fetch.ts
+++ b/src/pages/api/shipp/fetch.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from "astro";
+import { pollShippConnections } from "@/server/shipp/service";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const body = await request
+      .json()
+      .catch(() => ({} as { connectionIds?: string[]; limit?: number; useMock?: boolean }));
+
+    const result = await pollShippConnections({
+      connectionIds: Array.isArray(body.connectionIds) ? body.connectionIds : undefined,
+      limit: typeof body.limit === "number" ? body.limit : undefined,
+      useMock: body.useMock === true,
+    });
+
+    return new Response(JSON.stringify({ ok: true, ...result }, null, 2), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    return new Response(
+      JSON.stringify(
+        {
+          ok: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+        },
+        null,
+        2,
+      ),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+};

--- a/src/pages/api/shipp/signals.ts
+++ b/src/pages/api/shipp/signals.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from "astro";
+import { readShippState } from "@/server/shipp/state";
+
+export const prerender = false;
+
+export const GET: APIRoute = async () => {
+  const state = await readShippState();
+
+  return new Response(
+    JSON.stringify(
+      {
+        ok: true,
+        updatedAt: state.updatedAt,
+        connections: state.connections,
+        latestSignals: state.latestSignals,
+      },
+      null,
+      2,
+    ),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/src/pages/capital-game-dashboard.astro
+++ b/src/pages/capital-game-dashboard.astro
@@ -11,6 +11,7 @@ import {
   getNetFlow,
   sortEntriesByDate,
 } from "../data/capitalGame";
+import { readShippState } from "@/server/shipp/state";
 
 const currency = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -86,6 +87,9 @@ const actualPoints = series.map((point, idx) => `${idx * 88 + 20},${toChartY(poi
 const targetPoints = series
   .map((point, idx) => `${idx * 88 + 20},${toChartY(point.targetEquity)}`)
   .join(" ");
+
+const shippState = await readShippState();
+const latestSignals = shippState.latestSignals.slice(0, 6);
 ---
 
 <!doctype html>
@@ -178,6 +182,49 @@ const targetPoints = series
               ))}
             </svg>
           </div>
+        </div>
+
+        <div class="mt-10 overflow-hidden rounded-2xl border border-slate-700/80 bg-slate-900/70 p-5 sm:p-6">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p class="text-xs uppercase tracking-[0.18em] text-slate-400">Shipp Signal Feed (Debug)</p>
+              <p class="mt-1 text-xs text-slate-400">Manual fetch only. No auto-bets. Last state update: {shippState.updatedAt ?? "never"}</p>
+            </div>
+            <code class="rounded bg-slate-800 px-2 py-1 text-xs text-slate-300">POST /api/shipp/fetch</code>
+          </div>
+
+          {latestSignals.length > 0 ? (
+            <div class="mt-4 overflow-x-auto">
+              <table class="w-full min-w-[980px] border-collapse text-left text-sm">
+                <thead>
+                  <tr class="border-b border-slate-700/80 text-xs uppercase tracking-[0.18em] text-slate-400">
+                    <th class="px-2 py-3 font-medium">Received</th>
+                    <th class="px-2 py-3 font-medium">Sport</th>
+                    <th class="px-2 py-3 font-medium">Game</th>
+                    <th class="px-2 py-3 font-medium">Type</th>
+                    <th class="px-2 py-3 font-medium">Score</th>
+                    <th class="px-2 py-3 font-medium">Description</th>
+                    <th class="px-2 py-3 font-medium">Cursor</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {latestSignals.map((signal) => (
+                    <tr class="border-b border-slate-800/80 text-slate-200">
+                      <td class="whitespace-nowrap px-2 py-3">{new Date(signal.receivedAt).toLocaleString("en-US")}</td>
+                      <td class="whitespace-nowrap px-2 py-3 uppercase">{signal.sport ?? "—"}</td>
+                      <td class="whitespace-nowrap px-2 py-3">{signal.gameId ?? "—"}</td>
+                      <td class="whitespace-nowrap px-2 py-3">{signal.eventType ?? "—"}</td>
+                      <td class="whitespace-nowrap px-2 py-3">{signal.homePoints ?? "—"} - {signal.awayPoints ?? "—"}</td>
+                      <td class="px-2 py-3 text-slate-300">{signal.description ?? "—"}</td>
+                      <td class="whitespace-nowrap px-2 py-3 text-xs text-slate-400">{signal.eventCursor ?? "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p class="mt-4 text-sm text-slate-300">No signals yet. Trigger a manual fetch and refresh this page.</p>
+          )}
         </div>
 
         <div class="mt-10 overflow-hidden rounded-2xl border border-slate-700/80 bg-slate-900/70 shadow-2xl shadow-slate-950/60">

--- a/src/server/shipp/client.ts
+++ b/src/server/shipp/client.ts
@@ -1,0 +1,44 @@
+import type { PollConnectionInput, ShippRunResponse } from "./types";
+
+const SHIPP_BASE_URL = "https://api.shipp.ai/api/v1";
+
+const getApiKey = (): string => {
+  const key = import.meta.env.SHIPP_API_KEY?.trim();
+  if (!key) {
+    throw new Error("Missing SHIPP_API_KEY. Add it to your .env.local before running fetch.");
+  }
+  return key;
+};
+
+export const runShippConnection = async (
+  input: PollConnectionInput,
+): Promise<ShippRunResponse> => {
+  const apiKey = getApiKey();
+  const url = new URL(`${SHIPP_BASE_URL}/connections/${input.connectionId}`);
+  url.searchParams.set("api_key", apiKey);
+
+  const body: Record<string, unknown> = {
+    limit: input.limit ?? 100,
+  };
+
+  if (input.sinceEventId) {
+    body.since_event_id = input.sinceEventId;
+  } else if (input.since) {
+    body.since = input.since;
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Shipp request failed (${response.status}): ${errorText}`);
+  }
+
+  return (await response.json()) as ShippRunResponse;
+};

--- a/src/server/shipp/normalize.ts
+++ b/src/server/shipp/normalize.ts
@@ -1,0 +1,59 @@
+import type { JsonObject, NormalizedShippSignal } from "./types";
+
+const asString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value : null;
+
+const asNumber = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+};
+
+const firstString = (row: JsonObject, keys: string[]): string | null => {
+  for (const key of keys) {
+    const value = asString(row[key]);
+    if (value) return value;
+  }
+  return null;
+};
+
+export const getRowCursorId = (row: JsonObject): string | null =>
+  firstString(row, ["attribution_id", "event_id", "id"]);
+
+export const normalizeShippSignal = (
+  row: JsonObject,
+  connectionId: string,
+): NormalizedShippSignal => {
+  const receivedAt = new Date().toISOString();
+  const eventCursor = getRowCursorId(row);
+  const wallClockStart = firstString(row, ["wall_clock_start", "scheduled"]);
+  const gameId = firstString(row, ["game_id"]);
+  const sport = firstString(row, ["sport"]);
+  const eventType = firstString(row, ["type", "category"]);
+  const description = firstString(row, ["desc", "description"]);
+
+  const rawId = [connectionId, eventCursor ?? gameId ?? "unknown", wallClockStart ?? receivedAt].join(":");
+
+  return {
+    id: rawId,
+    connectionId,
+    eventCursor,
+    gameId,
+    sport,
+    eventType,
+    description,
+    period: asNumber(row.game_period),
+    gameClock: firstString(row, ["game_clock"]),
+    home: firstString(row, ["home", "home_team"]),
+    away: firstString(row, ["away", "away_team"]),
+    homePoints: asNumber(row.home_points),
+    awayPoints: asNumber(row.away_points),
+    wallClockStart,
+    wallClockEnd: firstString(row, ["wall_clock_end"]),
+    receivedAt,
+    raw: row,
+  };
+};

--- a/src/server/shipp/service.ts
+++ b/src/server/shipp/service.ts
@@ -1,0 +1,108 @@
+import { normalizeShippSignal, getRowCursorId } from "./normalize";
+import { runShippConnection } from "./client";
+import { getConnectionState, mergeSignals, readShippState, writeShippState } from "./state";
+import type { JsonObject, PollConnectionResult } from "./types";
+
+const defaultSince = () => new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+
+const resolveConnectionIds = (provided?: string[]): string[] => {
+  if (provided?.length) return provided;
+
+  const fromEnv = import.meta.env.SHIPP_CONNECTION_IDS?.split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+
+  if (fromEnv?.length) return fromEnv;
+
+  const single = import.meta.env.SHIPP_CONNECTION_ID?.trim();
+  return single ? [single] : [];
+};
+
+export const pollShippConnections = async (options?: {
+  connectionIds?: string[];
+  limit?: number;
+  useMock?: boolean;
+}): Promise<{ results: PollConnectionResult[]; statePath: string }> => {
+  const connectionIds = resolveConnectionIds(options?.connectionIds);
+
+  if (!connectionIds.length) {
+    throw new Error(
+      "No Shipp connection IDs configured. Set SHIPP_CONNECTION_ID or SHIPP_CONNECTION_IDS, or pass connectionIds in request body.",
+    );
+  }
+
+  const state = await readShippState();
+  const results: PollConnectionResult[] = [];
+
+  for (const connectionId of connectionIds) {
+    const connectionState = getConnectionState(state, connectionId);
+    state.connections[connectionId] = {
+      ...connectionState,
+      lastRunAt: new Date().toISOString(),
+      lastError: null,
+    };
+
+    try {
+      const rows: JsonObject[] = options?.useMock
+        ? [
+            {
+              attribution_id: `mock-${Date.now()}`,
+              game_id: "LAL-vs-BOS",
+              sport: "nba",
+              type: "score",
+              desc: "Mock signal for local integration validation",
+              game_period: 3,
+              game_clock: "04:12",
+              home: "Lakers",
+              away: "Celtics",
+              home_points: 92,
+              away_points: 95,
+              wall_clock_start: new Date().toISOString(),
+            },
+          ]
+        : (
+            await runShippConnection({
+              connectionId,
+              sinceEventId: connectionState.sinceEventId,
+              since: connectionState.sinceEventId ? undefined : defaultSince(),
+              limit: options?.limit ?? 100,
+            })
+          ).data ?? [];
+
+      const normalized = rows.map((row) => normalizeShippSignal(row, connectionId));
+      const lastCursor = [...rows]
+        .reverse()
+        .map((row) => getRowCursorId(row))
+        .find((id) => Boolean(id)) ?? connectionState.sinceEventId;
+
+      state.connections[connectionId] = {
+        ...state.connections[connectionId],
+        sinceEventId: lastCursor,
+        lastSuccessAt: new Date().toISOString(),
+        lastError: null,
+      };
+
+      state.latestSignals = mergeSignals(state.latestSignals, normalized);
+
+      results.push({
+        connectionId,
+        fetched: rows.length,
+        normalized,
+        nextSinceEventId: lastCursor,
+      });
+    } catch (error) {
+      state.connections[connectionId] = {
+        ...state.connections[connectionId],
+        lastError: error instanceof Error ? error.message : "Unknown error",
+      };
+      throw error;
+    }
+  }
+
+  await writeShippState(state);
+
+  return {
+    results,
+    statePath: "src/data/shipp-state.json",
+  };
+};

--- a/src/server/shipp/state.ts
+++ b/src/server/shipp/state.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { NormalizedShippSignal, ShippConnectionState, ShippState } from "./types";
+
+const SHIPP_STATE_FILE = path.join(process.cwd(), "src/data/shipp-state.json");
+const MAX_LATEST_SIGNALS = 100;
+
+const defaultConnectionState = (): ShippConnectionState => ({
+  sinceEventId: null,
+  lastRunAt: null,
+  lastSuccessAt: null,
+  lastError: null,
+});
+
+const defaultState = (): ShippState => ({
+  version: 1,
+  updatedAt: new Date().toISOString(),
+  connections: {},
+  latestSignals: [],
+});
+
+export const readShippState = async (): Promise<ShippState> => {
+  try {
+    const raw = await fs.readFile(SHIPP_STATE_FILE, "utf-8");
+    const parsed = JSON.parse(raw) as ShippState;
+    return {
+      ...defaultState(),
+      ...parsed,
+      connections: parsed.connections ?? {},
+      latestSignals: parsed.latestSignals ?? [],
+    };
+  } catch {
+    return defaultState();
+  }
+};
+
+export const writeShippState = async (state: ShippState): Promise<void> => {
+  const payload: ShippState = {
+    ...state,
+    updatedAt: new Date().toISOString(),
+    latestSignals: state.latestSignals.slice(0, MAX_LATEST_SIGNALS),
+  };
+
+  await fs.writeFile(SHIPP_STATE_FILE, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+};
+
+export const getConnectionState = (
+  state: ShippState,
+  connectionId: string,
+): ShippConnectionState => {
+  return state.connections[connectionId] ?? defaultConnectionState();
+};
+
+export const mergeSignals = (
+  existing: NormalizedShippSignal[],
+  incoming: NormalizedShippSignal[],
+): NormalizedShippSignal[] => {
+  const deduped = new Map<string, NormalizedShippSignal>();
+
+  for (const signal of [...incoming, ...existing]) {
+    deduped.set(signal.id, signal);
+  }
+
+  return [...deduped.values()]
+    .sort((a, b) => b.receivedAt.localeCompare(a.receivedAt))
+    .slice(0, MAX_LATEST_SIGNALS);
+};

--- a/src/server/shipp/types.ts
+++ b/src/server/shipp/types.ts
@@ -1,0 +1,54 @@
+export type JsonObject = Record<string, unknown>;
+
+export interface ShippRunResponse {
+  connection_id: string;
+  data?: JsonObject[];
+}
+
+export interface NormalizedShippSignal {
+  id: string;
+  connectionId: string;
+  eventCursor: string | null;
+  gameId: string | null;
+  sport: string | null;
+  eventType: string | null;
+  description: string | null;
+  period: number | null;
+  gameClock: string | null;
+  home: string | null;
+  away: string | null;
+  homePoints: number | null;
+  awayPoints: number | null;
+  wallClockStart: string | null;
+  wallClockEnd: string | null;
+  receivedAt: string;
+  raw: JsonObject;
+}
+
+export interface ShippConnectionState {
+  sinceEventId: string | null;
+  lastRunAt: string | null;
+  lastSuccessAt: string | null;
+  lastError: string | null;
+}
+
+export interface ShippState {
+  version: 1;
+  updatedAt: string | null;
+  connections: Record<string, ShippConnectionState>;
+  latestSignals: NormalizedShippSignal[];
+}
+
+export interface PollConnectionInput {
+  connectionId: string;
+  sinceEventId?: string | null;
+  since?: string;
+  limit?: number;
+}
+
+export interface PollConnectionResult {
+  connectionId: string;
+  fetched: number;
+  normalized: NormalizedShippSignal[];
+  nextSinceEventId: string | null;
+}


### PR DESCRIPTION
## Summary
- add server-side Shipp integration module with env-key auth (`SHIPP_API_KEY`)
- add cursor-based polling + typed normalization into a dashboard-safe signal shape
- add pragmatic state persistence in `src/data/shipp-state.json`
- add manual fetch route (`POST /api/shipp/fetch`) and read route (`GET /api/shipp/signals`)
- add Shipp debug section to `/capital-game-dashboard` (read-only, no auto-bets)
- add setup/run docs in `docs/shipp-integration.md`

## Notes
- keeps human-in-loop: no bet placement logic added
- supports `SHIPP_CONNECTION_ID` or `SHIPP_CONNECTION_IDS`
- includes `useMock` fetch mode for local validation without hitting live API

## Validation
- `yarn build` ✅
- `yarn astro check` ❌ (fails due to pre-existing repo-wide TS errors unrelated to this PR)
- manual API smoke test via local dev server + curl ✅
