### PR TITLE
Fix martingale tracker predictive state

### DIFF
--- a/docs/adding-martingale-bets.md
+++ b/docs/adding-martingale-bets.md
@@ -2,6 +2,26 @@
 
 Instructions for adding a new bet to the tracker and keeping the shipp.ai signal matching up to date.
 
+## Martingale system rules
+
+The martingale strategy tracks bets in **series**. Each series is identified by a letter (A, B, C, ...).
+
+1. **A series starts** with a single bet and **ends with a win**.
+2. **On a loss**, the series continues — the next bet **doubles** the previous stake.
+3. **On a win**, the series is complete. The next bet starts a **new series** with a fresh stake.
+4. **First bet in a new series**: the largest multiple of $10 where the person's balance is at least 15× the stake. Formula: `Math.floor(balance / 15 / 10) * 10`, minimum $10. This is implemented in `getNewSeriesStake()` in `martingaleBets.ts`.
+5. **"Next Stake" while in a series** (after a loss): always 2× the last bet's stake.
+
+### Hero display states
+
+The hero card shows the current state for each owner (Dan, GardenOf):
+
+| State | When | Shows |
+|---|---|---|
+| **Pending** | There's an active (unsettled) bet | The pick, line, series, and next stake if it loses (2×) |
+| **Continuing Series** | Last bet was a loss, no new bet placed | Current series letter, next stake (2× last), amber status |
+| **New Series Ready** | Last bet was a win, no new bet placed | Next series letter, fresh stake from balance, green status |
+
 ## Information needed for a new bet
 
 Provide all of these:

--- a/src/data/martingaleBets.ts
+++ b/src/data/martingaleBets.ts
@@ -351,3 +351,7 @@ export const getReturnAmount = (bet: MartingaleBet): number => {
 
 export const getNetImpact = (bet: MartingaleBet): number =>
   Number((getReturnAmount(bet) - getStakeOut(bet)).toFixed(2));
+
+/** First bet in a new series: largest multiple of 10 where balance >= 15× stake */
+export const getNewSeriesStake = (balance: number): number =>
+  Math.max(10, Math.floor(balance / 15 / 10) * 10);

--- a/src/pages/martingale-tracker.astro
+++ b/src/pages/martingale-tracker.astro
@@ -11,6 +11,7 @@ import {
   getStakeOut,
   getReturnAmount,
   getNetImpact,
+  getNewSeriesStake,
   type MartingaleBet,
 } from "../data/martingaleBets";
 import { readShippState } from "@/server/shipp/state";
@@ -71,7 +72,7 @@ interface HeroSeriesState {
   currentSeriesId: string | null;
   nextSeriesId: string | null;
   displaySeriesId: string | null;
-  status: "In Progress" | "New Series Ready";
+  status: "Pending" | "Continuing Series" | "New Series Ready";
   lastBetAmount: number | null;
   nextBetStake: number | null;
   lastBet: MartingaleBet | null;
@@ -84,7 +85,7 @@ const getNextSeriesId = (seriesId: string | null): string | null => {
   return String.fromCharCode(seriesId.charCodeAt(0) + 1);
 };
 
-const getHeroSeriesState = (bets: MartingaleBet[]): HeroSeriesState => {
+const getHeroSeriesState = (bets: MartingaleBet[], balance: number): HeroSeriesState => {
   const lastBet = bets[bets.length - 1] ?? null;
   if (!lastBet) {
     return {
@@ -93,7 +94,7 @@ const getHeroSeriesState = (bets: MartingaleBet[]): HeroSeriesState => {
       displaySeriesId: null,
       status: "New Series Ready",
       lastBetAmount: null,
-      nextBetStake: null,
+      nextBetStake: getNewSeriesStake(balance),
       lastBet: null,
     };
   }
@@ -106,20 +107,34 @@ const getHeroSeriesState = (bets: MartingaleBet[]): HeroSeriesState => {
       currentSeriesId: lastBet.seriesId,
       nextSeriesId,
       displaySeriesId: lastBet.seriesId,
-      status: "In Progress",
+      status: "Pending",
       lastBetAmount,
       nextBetStake: Number((lastBetAmount * 2).toFixed(2)),
       lastBet,
     };
   }
 
+  // Last bet was a loss — still in the same series, next bet doubles
+  if (lastBet.result === "loss") {
+    return {
+      currentSeriesId: lastBet.seriesId,
+      nextSeriesId,
+      displaySeriesId: lastBet.seriesId,
+      status: "Continuing Series",
+      lastBetAmount,
+      nextBetStake: Number((lastBetAmount * 2).toFixed(2)),
+      lastBet,
+    };
+  }
+
+  // Last bet was a win — series complete, new series starts fresh
   return {
     currentSeriesId: lastBet.seriesId,
     nextSeriesId,
     displaySeriesId: nextSeriesId,
     status: "New Series Ready",
     lastBetAmount,
-    nextBetStake: lastBetAmount,
+    nextBetStake: getNewSeriesStake(balance),
     lastBet,
   };
 };
@@ -181,7 +196,7 @@ const pendingBetCheckpoints = orderedBets
     return { bet, latestPacket };
   });
 
-const danHeroSeriesState = getHeroSeriesState(orderedBets);
+const danHeroSeriesState = getHeroSeriesState(orderedBets, currentBalance);
 
 const gardenSettledBets = gardenOrderedBets.filter((bet) => bet.result !== "pending");
 const gardenPendingBets = gardenOrderedBets.filter((bet) => bet.result === "pending").length;
@@ -237,7 +252,7 @@ const gardenPendingBetCheckpoints = gardenOrderedBets
     return { bet, latestPacket };
   });
 
-const gardenHeroSeriesState = getHeroSeriesState(gardenOrderedBets);
+const gardenHeroSeriesState = getHeroSeriesState(gardenOrderedBets, gardenCurrentBalance);
 
 // Hero active bets with checkpoint data merged in
 const danActiveBets = orderedBets
@@ -345,7 +360,9 @@ const gardenSeriesSummariesDesc = [...gardenSeriesSummaries].reverse();
               {danActiveBets.length > 0 ? (
                 <p class="text-3xl lg:text-4xl xl:text-5xl font-black text-white uppercase tracking-tight leading-none">{danActiveBets[0].pick}</p>
               ) : (
-                <p class="text-3xl lg:text-4xl xl:text-5xl font-black text-slate-600 uppercase tracking-tight leading-none">No Active Bet</p>
+                <div>
+                  <p class="text-3xl lg:text-4xl xl:text-5xl font-black text-slate-600 uppercase tracking-tight leading-none">No Current Bet</p>
+                </div>
               )}
             </div>
 
@@ -390,18 +407,20 @@ const gardenSeriesSummariesDesc = [...gardenSeriesSummaries].reverse();
                     </div>
                   ))
                 ) : (
-                  <div class="grid grid-cols-3 gap-3">
-                    <div>
-                      <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Series</p>
-                      <p class="font-mono text-xl font-bold text-cyan-300">{danHeroSeriesState.displaySeriesId ?? "—"}</p>
-                    </div>
-                    <div>
-                      <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Last Bet</p>
-                      <p class="font-mono text-xl font-bold text-rose-300">{danHeroSeriesState.lastBetAmount ? currency.format(danHeroSeriesState.lastBetAmount) : "—"}</p>
-                    </div>
-                    <div>
-                      <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Status</p>
-                      <p class="font-mono text-xl font-bold text-white">{danHeroSeriesState.status}</p>
+                  <div>
+                    <div class="grid grid-cols-3 gap-3">
+                      <div>
+                        <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">{danHeroSeriesState.status === "Continuing Series" ? "Series" : "Next Series"}</p>
+                        <p class="font-mono text-xl font-bold text-cyan-300">{danHeroSeriesState.displaySeriesId ?? "—"}</p>
+                      </div>
+                      <div>
+                        <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Next Stake</p>
+                        <p class="font-mono text-xl font-bold text-rose-300">{danHeroSeriesState.nextBetStake ? currency.format(danHeroSeriesState.nextBetStake) : "—"}</p>
+                      </div>
+                      <div>
+                        <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Status</p>
+                        <p class:list={["font-mono text-sm font-bold", danHeroSeriesState.status === "Continuing Series" ? "text-amber-300" : "text-emerald-400"]}>{danHeroSeriesState.status}</p>
+                      </div>
                     </div>
                   </div>
                 )}
@@ -445,18 +464,20 @@ const gardenSeriesSummariesDesc = [...gardenSeriesSummaries].reverse();
                     </div>
                   ))
                 ) : (
-                  <div class="grid grid-cols-3 gap-3">
-                    <div>
-                      <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Series</p>
-                      <p class="font-mono text-xl font-bold text-violet-300">{gardenHeroSeriesState.displaySeriesId ?? "—"}</p>
-                    </div>
-                    <div>
-                      <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Last Bet</p>
-                      <p class="font-mono text-xl font-bold text-rose-300">{gardenHeroSeriesState.lastBetAmount ? currency.format(gardenHeroSeriesState.lastBetAmount) : "—"}</p>
-                    </div>
-                    <div>
-                      <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Status</p>
-                      <p class="font-mono text-xl font-bold text-white">{gardenHeroSeriesState.status}</p>
+                  <div>
+                    <div class="grid grid-cols-3 gap-3">
+                      <div>
+                        <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">{gardenHeroSeriesState.status === "Continuing Series" ? "Series" : "Next Series"}</p>
+                        <p class="font-mono text-xl font-bold text-violet-300">{gardenHeroSeriesState.displaySeriesId ?? "—"}</p>
+                      </div>
+                      <div>
+                        <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Next Stake</p>
+                        <p class="font-mono text-xl font-bold text-rose-300">{gardenHeroSeriesState.nextBetStake ? currency.format(gardenHeroSeriesState.nextBetStake) : "—"}</p>
+                      </div>
+                      <div>
+                        <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Status</p>
+                        <p class:list={["font-mono text-sm font-bold", gardenHeroSeriesState.status === "Continuing Series" ? "text-amber-300" : "text-emerald-400"]}>{gardenHeroSeriesState.status}</p>
+                      </div>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary

Fixed the hero card's "no current bet" state to properly distinguish between continuing a loss-series (double next stake) and starting a fresh series (balance-based stake using 15× rule). Updated display labels and color-coding to make series progression clear.

- Added `getNewSeriesStake()` helper to calculate fresh stakes from balance
- Refactored `getHeroSeriesState()` to distinguish "Pending" / "Continuing Series" / "New Series Ready" states
- Updated hero display: shows "Series" vs "Next Series" label and next stake amount with appropriate colors (amber for continuing, green for fresh)
- Documented the full martingale system rules in `docs/adding-martingale-bets.md` for future agent runs

## Test plan

- Verify hero card shows correct next stake when last bet was a loss (2× previous)
- Verify hero card shows correct next stake when last bet was a win (fresh from balance)
- Check color coding: amber badge for "Continuing Series", green for "New Series Ready"

🤖 Generated with [Claude Code](https://claude.com/claude-code)