### PR TITLE
Show current stake in hero when bet is active

### DIFF
--- a/src/pages/martingale-tracker.astro
+++ b/src/pages/martingale-tracker.astro
@@ -385,8 +385,8 @@ const gardenSeriesSummariesDesc = [...gardenSeriesSummaries].reverse();
                           <p class="font-mono text-xl font-bold text-white">{bet.line}</p>
                         </div>
                         <div>
-                          <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Next Stake</p>
-                          <p class="font-mono text-xl font-bold text-rose-300">{currency.format(danHeroSeriesState.nextBetStake ?? getStakeOut(bet) * 2)}</p>
+                          <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Stake</p>
+                          <p class="font-mono text-xl font-bold text-rose-300">{currency.format(getStakeOut(bet))}</p>
                         </div>
                       </div>
                       {bet.latestPacket ? (
@@ -442,8 +442,8 @@ const gardenSeriesSummariesDesc = [...gardenSeriesSummaries].reverse();
                           <p class="font-mono text-xl font-bold text-white">{bet.line}</p>
                         </div>
                         <div>
-                          <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Next Stake</p>
-                          <p class="font-mono text-xl font-bold text-rose-300">{currency.format(gardenHeroSeriesState.nextBetStake ?? getStakeOut(bet) * 2)}</p>
+                          <p class="font-mono text-[8px] uppercase tracking-[0.2em] text-slate-500 mb-1">Stake</p>
+                          <p class="font-mono text-xl font-bold text-rose-300">{currency.format(getStakeOut(bet))}</p>
                         </div>
                       </div>
                       {bet.latestPacket ? (


### PR DESCRIPTION
## Summary
- When a bet is pending, the hero section now shows the actual current stake amount instead of the hypothetical next doubled amount
- Changes apply to both Dan and GardenOf active bet displays
- Standby/no-active-bet view still shows predictive "Next Stake" info as before

## Test plan
- [ ] Verify hero shows correct current stake amounts when bets are pending
- [ ] Verify standby mode still shows next stake correctly when no bets are active

🤖 Generated with [Claude Code](https://claude.com/claude-code)