### PR TITLE
Add Hi Drake greeting to plus-ev page

### DIFF
--- a/src/pages/plus-ev/index.astro
+++ b/src/pages/plus-ev/index.astro
@@ -179,6 +179,7 @@ const startDateStr = firstBetDate.toLocaleDateString("en-US", {
     </div>
 
     <main>
+      <p class="text-center text-2xl font-bold py-4 text-emerald-400">Hi Drake</p>
       <h1 class="sr-only">Plus EV</h1>
 
       <!-- Today's Action (repurposed hero) -->


### PR DESCRIPTION
Adds a centered "Hi Drake" greeting in emerald green at the top of the plus-ev page for a demo.