### PR TITLE
feat(home): animate SVG hero intro with staggered fade-up

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,32 +60,32 @@ const monthName = getMonthName();
             >
               <path
                 d="M294 375.984V0H344.4L378 208.992V0H421.68V375.984H371.28L337.68 166.992V375.984H294Z"
-                class="fill-slate-200"></path>
+                class="fill-slate-200 svg-letter" style="--svg-delay: 100ms"></path>
               <path
                 d="M230.094 375.984L222.702 285.264H190.446L183.054 375.984H142.734L172.974 0H243.534L273.774 375.984H230.094ZM193.47 244.944H219.678L206.574 83.664L193.47 244.944Z"
-                class="fill-slate-200"></path>
+                class="fill-slate-200 svg-letter" style="--svg-delay: 50ms"></path>
               <path
                 d="M0 375.984V0H63.84C106.512 0 127.68 21.168 127.68 63.84V312.144C127.68 354.816 106.512 375.984 63.84 375.984H0ZM47.04 335.664H63.84C75.264 335.664 80.64 329.952 80.64 318.864V57.12C80.64 46.032 75.264 40.32 63.84 40.32H47.04V335.664Z"
-                class="fill-slate-200"></path>
+                class="fill-slate-200 svg-letter" style="--svg-delay: 0ms"></path>
               <path
                 d="M659.92 679.984V344.284H716.92C755.02 344.284 773.92 363.184 773.92 401.284V622.984C773.92 661.084 755.02 679.984 716.92 679.984H659.92ZM701.92 643.984H716.92C727.12 643.984 731.92 638.884 731.92 628.984V395.284C731.92 385.384 727.12 380.284 716.92 380.284H701.92V643.984Z"
-                class="fill-slate-200"></path>
+                class="fill-slate-200 svg-letter" style="--svg-delay: 200ms"></path>
               <path
                 d="M792.049 679.984V344.284H891.049V380.284H834.049V484.384H876.049V520.384H834.049V643.984H891.049V679.984H792.049Z"
-                class="fill-slate-200"></path>
+                class="fill-slate-200 svg-letter" style="--svg-delay: 250ms"></path>
               <path
                 d="M908.943 679.984V344.284H953.943L983.943 530.884V344.284H1022.94V679.984H977.943L947.943 493.384V679.984H908.943Z"
-                class="fill-slate-200"></path>
+                class="fill-slate-200 svg-letter" style="--svg-delay: 300ms"></path>
               <path
                 d="M1041.07 679.984V344.284H1086.07L1116.07 530.884V344.284H1155.07V679.984H1110.07L1080.07 493.384V679.984H1041.07Z"
-                class="fill-slate-200"></path>
+                class="fill-slate-200 svg-letter" style="--svg-delay: 350ms"></path>
               <path
                 d="M1173.2 679.984V344.284H1272.2V380.284H1215.2V484.384H1257.2V520.384H1215.2V643.984H1272.2V679.984H1173.2Z"
-                class="fill-slate-200"></path>
+                class="fill-slate-200 svg-letter" style="--svg-delay: 400ms"></path>
               <path
                 d="M1330.6 344.284L1353.1 465.784L1374.1 344.284H1410.1L1372.6 552.784V679.984H1330.6V552.784L1290.1 344.284H1330.6Z"
-                class="fill-slate-200"></path>
-              <g clip-path="url(#clip0_324_81)">
+                class="fill-slate-200 svg-letter" style="--svg-delay: 450ms"></path>
+              <g clip-path="url(#clip0_324_81)" class="svg-char" style="--svg-delay: 150ms">
                 <mask
                   id="mask0_324_81"
                   style="mask-type:luminance"
@@ -831,3 +831,29 @@ const monthName = getMonthName();
     <Footer />
   </body>
 </html>
+
+<style>
+  @keyframes svg-fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .svg-letter,
+  .svg-char {
+    animation: svg-fade-up 500ms cubic-bezier(0.23, 1, 0.32, 1) both;
+    animation-delay: var(--svg-delay, 0ms);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .svg-letter,
+    .svg-char {
+      animation: none;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

- Adds staggered entrance animation to the large `DAN DENNEY` SVG hero on the home page
- Letters animate left-to-right: D→A→N (top row), then the character illustration, then D→E→N→N→E→Y (bottom row), each 50ms apart
- Uses `opacity` + `translateY` only (no layout-triggering properties), `ease-out-quint` easing, 500ms duration
- Full `prefers-reduced-motion` support — animations are disabled for users who prefer it

## Changed Files

**Pages**
- `src/pages/index.astro` — added `svg-letter`/`svg-char` classes and `--svg-delay` custom properties to each letter path and the character group; added scoped `@keyframes svg-fade-up` with reduced-motion media query

## Test plan

- [ ] Load home page and confirm all letters and character animate in with a left-to-right wave
- [ ] Verify no layout shift during or after the animation
- [ ] Test with `prefers-reduced-motion: reduce` enabled — all elements should appear instantly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)