### PR TITLE
feat(tools): favicon checker replicating Google's lookup

### DIFF
--- a/src/pages/api/favicon-check.ts
+++ b/src/pages/api/favicon-check.ts
@@ -1,0 +1,436 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+/**
+ * Favicon checker — replicates how Google discovers and fetches a site's favicon.
+ *
+ * Google's documented algorithm:
+ *   1. Crawl the page HTML with Googlebot.
+ *   2. Look for <link rel="icon"> / "shortcut icon" / "apple-touch-icon" in the head.
+ *   3. Fall back to /favicon.ico at the site root if no link tag is found.
+ *   4. Fetch the icon file with Googlebot-Image. The page AND the icon must both be
+ *      crawlable (not blocked by robots.txt) and the icon must be a valid square image.
+ *
+ * The browser can't set a custom User-Agent or fetch cross-origin, so the real lookup
+ * has to happen here on the server.
+ */
+
+// User agents Google uses, per https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers
+const GOOGLEBOT_UA =
+  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+const GOOGLEBOT_IMAGE_UA = 'Googlebot-Image/1.0';
+
+const FETCH_TIMEOUT_MS = 10000;
+const MAX_ICON_BYTES = 5 * 1024 * 1024; // 5MB safety cap
+
+interface Diagnostic {
+  level: 'pass' | 'warn' | 'fail';
+  message: string;
+}
+
+interface Candidate {
+  source: 'link' | 'fallback';
+  rel: string | null;
+  declaredSizes: string | null;
+  requestedUrl: string;
+  finalUrl: string | null;
+  redirected: boolean;
+  status: number | null;
+  ok: boolean;
+  contentType: string | null;
+  sizeBytes: number | null;
+  dimensions: { width: number; height: number } | null;
+  format: string | null;
+  dataUri: string | null;
+  robotsAllowed: boolean | null;
+  diagnostics: Diagnostic[];
+}
+
+async function fetchWithTimeout(url: string, ua: string, redirect: RequestRedirect = 'follow') {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      headers: { 'User-Agent': ua, Accept: '*/*' },
+      redirect,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Normalize user input into a fetchable URL. */
+function normalizeUrl(raw: string): URL | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    return new URL(withScheme);
+  } catch {
+    return null;
+  }
+}
+
+/** Pull out the raw <link rel="...icon..."> tags from a page's <head>. */
+function extractIconLinks(html: string): { raw: string; rel: string; href: string; sizes: string | null }[] {
+  const head = html.match(/<head[^>]*>([\s\S]*?)<\/head>/i)?.[1] ?? html;
+  const links: { raw: string; rel: string; href: string; sizes: string | null }[] = [];
+  const linkRe = /<link\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = linkRe.exec(head)) !== null) {
+    const tag = m[0];
+    const rel = tag.match(/\brel\s*=\s*["']?([^"'>]+)["']?/i)?.[1]?.trim().toLowerCase();
+    if (!rel) continue;
+    const isIcon = /(^|\s)(shortcut\s+icon|icon|apple-touch-icon(-precomposed)?|mask-icon|fluid-icon)(\s|$)/.test(rel);
+    if (!isIcon) continue;
+    const href = tag.match(/\bhref\s*=\s*["']?([^"'>\s]+)["']?/i)?.[1];
+    if (!href) continue;
+    const sizes = tag.match(/\bsizes\s*=\s*["']?([^"'>]+)["']?/i)?.[1]?.trim() ?? null;
+    links.push({ raw: tag, rel, href, sizes });
+  }
+  return links;
+}
+
+/** Lightweight image dimension sniffing from the first bytes of common formats. */
+function sniffImage(bytes: Uint8Array, contentType: string | null): {
+  format: string | null;
+  dimensions: { width: number; height: number } | null;
+} {
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const len = bytes.length;
+
+  // PNG
+  if (len >= 24 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) {
+    return { format: 'PNG', dimensions: { width: dv.getUint32(16), height: dv.getUint32(20) } };
+  }
+  // GIF
+  if (len >= 10 && bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46) {
+    return { format: 'GIF', dimensions: { width: dv.getUint16(6, true), height: dv.getUint16(8, true) } };
+  }
+  // ICO — pick the largest entry in the directory
+  if (len >= 6 && dv.getUint16(0, true) === 0 && dv.getUint16(2, true) === 1) {
+    const count = dv.getUint16(4, true);
+    let best: { width: number; height: number } | null = null;
+    for (let i = 0; i < count; i++) {
+      const off = 6 + i * 16;
+      if (off + 1 >= len) break;
+      const w = bytes[off] === 0 ? 256 : bytes[off];
+      const h = bytes[off + 1] === 0 ? 256 : bytes[off + 1];
+      if (!best || w * h > best.width * best.height) best = { width: w, height: h };
+    }
+    return { format: 'ICO', dimensions: best };
+  }
+  // JPEG — scan for a Start-of-Frame marker
+  if (len >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    let off = 2;
+    while (off + 9 < len) {
+      if (bytes[off] !== 0xff) { off++; continue; }
+      const marker = bytes[off + 1];
+      const isSOF = marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+      if (isSOF) {
+        return { format: 'JPEG', dimensions: { width: dv.getUint16(off + 7), height: dv.getUint16(off + 5) } };
+      }
+      off += 2 + dv.getUint16(off + 2);
+    }
+    return { format: 'JPEG', dimensions: null };
+  }
+  // SVG (vector — no pixel dimensions)
+  const head = new TextDecoder().decode(bytes.slice(0, 256)).trim();
+  if ((contentType?.includes('svg')) || head.startsWith('<svg') || (head.startsWith('<?xml') && head.includes('<svg'))) {
+    return { format: 'SVG', dimensions: null };
+  }
+  // WebP
+  if (len >= 12 && bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[8] === 0x57 && bytes[9] === 0x45) {
+    return { format: 'WebP', dimensions: null };
+  }
+  return { format: null, dimensions: null };
+}
+
+/** Minimal robots.txt parser — is `path` allowed for the given UA token? */
+function isAllowedByRobots(robotsTxt: string, uaToken: string, path: string): boolean {
+  const lines = robotsTxt.split(/\r?\n/).map((l) => l.replace(/#.*$/, '').trim());
+  // Collect rule groups keyed by user-agent.
+  const groups: { agents: string[]; rules: { allow: boolean; value: string }[] }[] = [];
+  let current: { agents: string[]; rules: { allow: boolean; value: string }[] } | null = null;
+  let lastWasAgent = false;
+  for (const line of lines) {
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const field = line.slice(0, colon).trim().toLowerCase();
+    const value = line.slice(colon + 1).trim();
+    if (field === 'user-agent') {
+      if (!current || !lastWasAgent) {
+        current = { agents: [], rules: [] };
+        groups.push(current);
+      }
+      current.agents.push(value.toLowerCase());
+      lastWasAgent = true;
+    } else if ((field === 'allow' || field === 'disallow') && current) {
+      current.rules.push({ allow: field === 'allow', value });
+      lastWasAgent = false;
+    } else {
+      lastWasAgent = false;
+    }
+  }
+
+  const token = uaToken.toLowerCase();
+  // Prefer a group matching the specific token, else fall back to "*".
+  const specific = groups.find((g) => g.agents.some((a) => token.includes(a) && a !== '*'));
+  const wildcard = groups.find((g) => g.agents.includes('*'));
+  const group = specific ?? wildcard;
+  if (!group) return true;
+
+  // Longest-match rule wins (per the robots spec).
+  let decision: boolean | null = null;
+  let matchLen = -1;
+  for (const rule of group.rules) {
+    if (rule.value === '') {
+      if (!rule.allow) continue; // empty Disallow = allow all, no path constraint
+    }
+    const pattern = rule.value;
+    if (matchesRobotsPattern(path, pattern) && pattern.length > matchLen) {
+      decision = rule.allow;
+      matchLen = pattern.length;
+    }
+  }
+  return decision ?? true;
+}
+
+function matchesRobotsPattern(path: string, pattern: string): boolean {
+  if (pattern === '') return false;
+  // Translate robots wildcards (* and $) into a regex.
+  const anchoredEnd = pattern.endsWith('$');
+  const body = anchoredEnd ? pattern.slice(0, -1) : pattern;
+  const escaped = body.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  const re = new RegExp('^' + escaped + (anchoredEnd ? '$' : ''));
+  return re.test(path);
+}
+
+async function inspectCandidate(
+  iconUrl: string,
+  source: 'link' | 'fallback',
+  rel: string | null,
+  declaredSizes: string | null,
+  robotsTxt: string | null,
+): Promise<Candidate> {
+  const candidate: Candidate = {
+    source,
+    rel,
+    declaredSizes,
+    requestedUrl: iconUrl,
+    finalUrl: null,
+    redirected: false,
+    status: null,
+    ok: false,
+    contentType: null,
+    sizeBytes: null,
+    dimensions: null,
+    format: null,
+    dataUri: null,
+    robotsAllowed: null,
+    diagnostics: [],
+  };
+
+  // robots.txt check (Googlebot-Image must be allowed to fetch the icon).
+  if (robotsTxt !== null) {
+    try {
+      const path = new URL(iconUrl).pathname + new URL(iconUrl).search;
+      candidate.robotsAllowed = isAllowedByRobots(robotsTxt, 'googlebot-image', path);
+      if (!candidate.robotsAllowed) {
+        candidate.diagnostics.push({
+          level: 'fail',
+          message: 'Blocked by robots.txt — Googlebot-Image is disallowed from fetching this path.',
+        });
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  try {
+    const res = await fetchWithTimeout(iconUrl, GOOGLEBOT_IMAGE_UA);
+    candidate.status = res.status;
+    candidate.ok = res.ok;
+    candidate.finalUrl = res.url;
+    candidate.redirected = res.redirected;
+    candidate.contentType = res.headers.get('content-type');
+
+    if (!res.ok) {
+      candidate.diagnostics.push({
+        level: 'fail',
+        message: `Icon returned HTTP ${res.status} — Google can't fetch it.`,
+      });
+      return candidate;
+    }
+
+    const buf = new Uint8Array(await res.arrayBuffer());
+    candidate.sizeBytes = buf.length;
+    if (buf.length > MAX_ICON_BYTES) {
+      candidate.diagnostics.push({ level: 'warn', message: 'Icon is unusually large (>5MB).' });
+    }
+
+    const { format, dimensions } = sniffImage(buf, candidate.contentType);
+    candidate.format = format;
+    candidate.dimensions = dimensions;
+
+    const isImageType = candidate.contentType?.startsWith('image/');
+    if (!isImageType && !format) {
+      candidate.diagnostics.push({
+        level: 'fail',
+        message: `Not served as an image (content-type: ${candidate.contentType ?? 'none'}).`,
+      });
+    }
+
+    // Build a data URI so the preview shows exactly what Googlebot-Image received.
+    if (buf.length <= MAX_ICON_BYTES) {
+      const mime = candidate.contentType?.split(';')[0] || (format ? `image/${format.toLowerCase()}` : 'application/octet-stream');
+      // Base64 encode in chunks to avoid call-stack limits.
+      let binary = '';
+      for (let i = 0; i < buf.length; i += 0x8000) {
+        binary += String.fromCharCode(...buf.subarray(i, i + 0x8000));
+      }
+      candidate.dataUri = `data:${mime};base64,${btoa(binary)}`;
+    }
+
+    // Dimension diagnostics (Google needs a square icon, min 8x8, ideally a multiple of 48px).
+    if (dimensions) {
+      const { width, height } = dimensions;
+      if (width < 8 || height < 8) {
+        candidate.diagnostics.push({ level: 'fail', message: `Too small (${width}×${height}). Google requires at least 8×8.` });
+      } else if (width !== height) {
+        candidate.diagnostics.push({ level: 'warn', message: `Not square (${width}×${height}). Google prefers a square icon.` });
+      } else if (width % 48 !== 0) {
+        candidate.diagnostics.push({ level: 'warn', message: `${width}×${height} is valid, but Google prefers a multiple of 48px (48, 96, 144…).` });
+      } else {
+        candidate.diagnostics.push({ level: 'pass', message: `${width}×${height} — good size for Google.` });
+      }
+    } else if (format === 'SVG') {
+      candidate.diagnostics.push({ level: 'pass', message: 'SVG (scalable) — Google supports SVG favicons.' });
+    }
+
+    if (candidate.ok && !candidate.diagnostics.some((d) => d.level === 'fail')) {
+      candidate.diagnostics.unshift({ level: 'pass', message: 'Fetched successfully by Googlebot-Image.' });
+    }
+  } catch (err) {
+    candidate.diagnostics.push({
+      level: 'fail',
+      message: `Request failed: ${(err as Error).name === 'AbortError' ? 'timed out' : (err as Error).message}.`,
+    });
+  }
+
+  return candidate;
+}
+
+export const GET: APIRoute = async ({ url }) => {
+  const input = url.searchParams.get('url') ?? '';
+  const target = normalizeUrl(input);
+
+  if (!target) {
+    return json({ error: 'Please provide a valid URL or domain.' }, 400);
+  }
+
+  const result: {
+    input: string;
+    normalizedUrl: string;
+    page: { status: number | null; ok: boolean; finalUrl: string | null; error: string | null };
+    rawLinkTags: string[];
+    robotsFound: boolean;
+    candidates: Candidate[];
+    verdict: { level: 'pass' | 'warn' | 'fail'; message: string };
+  } = {
+    input,
+    normalizedUrl: target.toString(),
+    page: { status: null, ok: false, finalUrl: null, error: null },
+    rawLinkTags: [],
+    robotsFound: false,
+    candidates: [],
+    verdict: { level: 'fail', message: '' },
+  };
+
+  // 1. Fetch robots.txt (so we can evaluate crawlability like Google does).
+  let robotsTxt: string | null = null;
+  try {
+    const robotsRes = await fetchWithTimeout(new URL('/robots.txt', target).toString(), GOOGLEBOT_UA);
+    if (robotsRes.ok) {
+      robotsTxt = await robotsRes.text();
+      result.robotsFound = true;
+    }
+  } catch {
+    /* no robots.txt is fine */
+  }
+
+  // 2. Fetch the page HTML with Googlebot.
+  let html = '';
+  let pageUrl = target.toString();
+  try {
+    const pageRes = await fetchWithTimeout(target.toString(), GOOGLEBOT_UA);
+    result.page.status = pageRes.status;
+    result.page.ok = pageRes.ok;
+    result.page.finalUrl = pageRes.url;
+    pageUrl = pageRes.url || pageUrl;
+    if (pageRes.ok) {
+      html = await pageRes.text();
+    } else {
+      result.page.error = `Page returned HTTP ${pageRes.status}.`;
+    }
+  } catch (err) {
+    result.page.error = `Couldn't load the page: ${(err as Error).name === 'AbortError' ? 'timed out' : (err as Error).message}.`;
+  }
+
+  // 3. Discover icon <link> tags, resolve them, and queue the /favicon.ico fallback.
+  const seen = new Set<string>();
+  const queue: { url: string; source: 'link' | 'fallback'; rel: string | null; sizes: string | null }[] = [];
+
+  if (html) {
+    const links = extractIconLinks(html);
+    for (const link of links) {
+      result.rawLinkTags.push(link.raw);
+      try {
+        const resolved = new URL(link.href, pageUrl).toString();
+        if (seen.has(resolved)) continue;
+        seen.add(resolved);
+        queue.push({ url: resolved, source: 'link', rel: link.rel, sizes: link.sizes });
+      } catch {
+        /* skip unparseable href */
+      }
+    }
+  }
+
+  // Always check the root /favicon.ico fallback, like Google does.
+  const fallback = new URL('/favicon.ico', target).toString();
+  if (!seen.has(fallback)) {
+    seen.add(fallback);
+    queue.push({ url: fallback, source: 'fallback', rel: null, sizes: null });
+  }
+
+  // 4. Fetch each candidate with Googlebot-Image.
+  result.candidates = await Promise.all(
+    queue.map((c) => inspectCandidate(c.url, c.source, c.rel, c.sizes, robotsTxt)),
+  );
+
+  // 5. Overall verdict.
+  const usable = result.candidates.find(
+    (c) => c.ok && c.robotsAllowed !== false && !c.diagnostics.some((d) => d.level === 'fail'),
+  );
+  if (!result.page.ok && result.candidates.every((c) => !c.ok)) {
+    result.verdict = { level: 'fail', message: "Couldn't reach the site or find any favicon Google could use." };
+  } else if (usable) {
+    const where = usable.source === 'link' ? 'a declared <link> icon' : 'the /favicon.ico fallback';
+    result.verdict = { level: 'pass', message: `Google should be able to show a favicon from ${where}.` };
+  } else if (result.candidates.some((c) => c.ok)) {
+    result.verdict = { level: 'warn', message: 'A favicon was found, but it has issues that may stop Google from using it.' };
+  } else {
+    result.verdict = { level: 'fail', message: 'No favicon Google could fetch was found.' };
+  }
+
+  return json(result, 200);
+};
+
+function json(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+  });
+}

--- a/src/pages/tools/favicon-checker.astro
+++ b/src/pages/tools/favicon-checker.astro
@@ -1,0 +1,467 @@
+---
+import BaseHead from "@/components/BaseHead.astro";
+import Header from "@/components/Header.astro";
+import Footer from "@/components/Footer.astro";
+
+export const prerender = true;
+
+const title = "Favicon Checker";
+const description =
+  "Check whether Google can find and use your site's favicon. Replicates Googlebot and Googlebot-Image fetching favicons the way Google Search does.";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={title} description={description} />
+  </head>
+  <body>
+    <main class="relative shadow-xs z-10">
+      <Header title={title} />
+      <div class="fc">
+        <header class="fc-intro">
+          <h1>Favicon Checker</h1>
+          <p>
+            See your site's favicon the way Google Search does. We crawl the page
+            with <code>Googlebot</code>, read the <code>&lt;link rel="icon"&gt;</code>
+            tags, then fetch each icon (and the <code>/favicon.ico</code> fallback)
+            with <code>Googlebot-Image</code> — checking robots.txt, status, format,
+            and size along the way.
+          </p>
+        </header>
+
+        <form id="fc-form" class="fc-form" autocomplete="off">
+          <label for="fc-url" class="fc-label">Site URL or domain</label>
+          <div class="fc-input-row">
+            <input
+              id="fc-url"
+              name="url"
+              type="text"
+              inputmode="url"
+              placeholder="example.com"
+              required
+            />
+            <button type="submit" id="fc-submit">Check</button>
+          </div>
+          <p class="fc-hint">No <code>https://</code>? We'll add it for you.</p>
+        </form>
+
+        <div id="fc-status" class="fc-status" hidden></div>
+        <div id="fc-results" class="fc-results"></div>
+      </div>
+    </main>
+    <Footer />
+
+    <script>
+      interface Diagnostic {
+        level: "pass" | "warn" | "fail";
+        message: string;
+      }
+      interface Candidate {
+        source: "link" | "fallback";
+        rel: string | null;
+        declaredSizes: string | null;
+        requestedUrl: string;
+        finalUrl: string | null;
+        redirected: boolean;
+        status: number | null;
+        ok: boolean;
+        contentType: string | null;
+        sizeBytes: number | null;
+        dimensions: { width: number; height: number } | null;
+        format: string | null;
+        dataUri: string | null;
+        robotsAllowed: boolean | null;
+        diagnostics: Diagnostic[];
+      }
+      interface CheckResult {
+        error?: string;
+        input: string;
+        normalizedUrl: string;
+        page: { status: number | null; ok: boolean; finalUrl: string | null; error: string | null };
+        rawLinkTags: string[];
+        robotsFound: boolean;
+        candidates: Candidate[];
+        verdict: { level: "pass" | "warn" | "fail"; message: string };
+      }
+
+      const form = document.getElementById("fc-form") as HTMLFormElement;
+      const input = document.getElementById("fc-url") as HTMLInputElement;
+      const submit = document.getElementById("fc-submit") as HTMLButtonElement;
+      const statusEl = document.getElementById("fc-status") as HTMLDivElement;
+      const resultsEl = document.getElementById("fc-results") as HTMLDivElement;
+
+      const esc = (s: string) =>
+        s.replace(/[&<>"']/g, (c) =>
+          ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string),
+        );
+
+      const formatBytes = (n: number | null) => {
+        if (n == null) return "—";
+        if (n < 1024) return `${n} B`;
+        if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+        return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+      };
+
+      const verdictBadge = (level: string) =>
+        ({ pass: "✓ Pass", warn: "▲ Warning", fail: "✕ Fail" }[level] ?? level);
+
+      function setStatus(msg: string, kind: "loading" | "error" | "") {
+        statusEl.hidden = !msg;
+        statusEl.textContent = msg;
+        statusEl.className = `fc-status ${kind ? `fc-status--${kind}` : ""}`.trim();
+      }
+
+      function renderCandidate(c: Candidate): string {
+        const worst = c.diagnostics.some((d) => d.level === "fail")
+          ? "fail"
+          : c.diagnostics.some((d) => d.level === "warn")
+            ? "warn"
+            : "pass";
+
+        const preview = c.dataUri
+          ? `<img src="${esc(c.dataUri)}" alt="favicon preview" />`
+          : `<span class="fc-noimg">no image</span>`;
+
+        const rows: [string, string][] = [
+          ["Source", c.source === "link" ? `<code>&lt;link rel="${esc(c.rel ?? "")}"&gt;</code>` : "/favicon.ico fallback"],
+          ["Requested", `<a href="${esc(c.requestedUrl)}" target="_blank" rel="noopener">${esc(c.requestedUrl)}</a>`],
+          ["Status", c.status != null ? `<strong>${c.status}</strong>${c.redirected ? ` (redirected)` : ""}` : "—"],
+          ["Content-Type", c.contentType ? esc(c.contentType) : "—"],
+          ["Format", c.format ?? "—"],
+          ["Dimensions", c.dimensions ? `${c.dimensions.width}×${c.dimensions.height}` : c.format === "SVG" ? "scalable" : "—"],
+          ["Size", formatBytes(c.sizeBytes)],
+          ["robots.txt", c.robotsAllowed == null ? "—" : c.robotsAllowed ? "allowed" : "blocked"],
+        ];
+        if (c.declaredSizes) rows.push(["Declared sizes", esc(c.declaredSizes)]);
+        if (c.redirected && c.finalUrl) rows.push(["Final URL", `<a href="${esc(c.finalUrl)}" target="_blank" rel="noopener">${esc(c.finalUrl)}</a>`]);
+
+        const diag = c.diagnostics
+          .map((d) => `<li class="fc-diag fc-diag--${d.level}">${esc(d.message)}</li>`)
+          .join("");
+
+        return `
+          <article class="fc-card fc-card--${worst}">
+            <div class="fc-card-head">
+              <div class="fc-preview">${preview}</div>
+              <div class="fc-card-title">
+                <span class="fc-tag fc-tag--${c.source}">${c.source === "link" ? "declared" : "fallback"}</span>
+                <span class="fc-badge fc-badge--${worst}">${verdictBadge(worst)}</span>
+              </div>
+            </div>
+            <dl class="fc-meta">
+              ${rows.map(([k, v]) => `<div><dt>${k}</dt><dd>${v}</dd></div>`).join("")}
+            </dl>
+            ${diag ? `<ul class="fc-diags">${diag}</ul>` : ""}
+          </article>`;
+      }
+
+      function render(data: CheckResult) {
+        const pageLine = data.page.ok
+          ? `Crawled <code>${esc(data.page.finalUrl ?? data.normalizedUrl)}</code> (HTTP ${data.page.status}) as Googlebot.`
+          : `Page fetch problem: ${esc(data.page.error ?? "unknown")}`;
+
+        const linkTags = data.rawLinkTags.length
+          ? `<details class="fc-raw"><summary>${data.rawLinkTags.length} icon &lt;link&gt; tag${data.rawLinkTags.length > 1 ? "s" : ""} found</summary><pre>${data.rawLinkTags.map(esc).join("\n")}</pre></details>`
+          : `<p class="fc-raw fc-raw--empty">No icon <code>&lt;link&gt;</code> tags in the page head — Google would rely on the <code>/favicon.ico</code> fallback.</p>`;
+
+        resultsEl.innerHTML = `
+          <div class="fc-verdict fc-verdict--${data.verdict.level}">
+            <span class="fc-badge fc-badge--${data.verdict.level}">${verdictBadge(data.verdict.level)}</span>
+            <p>${esc(data.verdict.message)}</p>
+          </div>
+          <div class="fc-summary">
+            <p>${pageLine}</p>
+            <p class="fc-robots">${data.robotsFound ? "robots.txt found and applied." : "No robots.txt found (nothing blocking the crawl)."}</p>
+            ${linkTags}
+          </div>
+          <div class="fc-grid">${data.candidates.map(renderCandidate).join("")}</div>
+        `;
+      }
+
+      form.addEventListener("submit", async (e) => {
+        e.preventDefault();
+        const value = input.value.trim();
+        if (!value) return;
+
+        submit.disabled = true;
+        resultsEl.innerHTML = "";
+        setStatus("Crawling as Googlebot and fetching favicons…", "loading");
+
+        try {
+          const res = await fetch(`/api/favicon-check?url=${encodeURIComponent(value)}`);
+          const data: CheckResult = await res.json();
+          if (!res.ok || data.error) {
+            setStatus(data.error ?? `Request failed (HTTP ${res.status}).`, "error");
+            return;
+          }
+          setStatus("", "");
+          render(data);
+        } catch (err) {
+          setStatus(`Something went wrong: ${(err as Error).message}`, "error");
+        } finally {
+          submit.disabled = false;
+        }
+      });
+    </script>
+
+    <style>
+      .fc {
+        max-width: 920px;
+        margin: 0 auto;
+        padding: 2rem 1.25rem 4rem;
+      }
+      .fc-intro h1 {
+        font-size: 2rem;
+        margin: 0 0 0.5rem;
+      }
+      .fc-intro p {
+        color: var(--gray, #535353);
+        line-height: 1.6;
+        max-width: 60ch;
+      }
+      .fc code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.85em;
+        background: rgb(0 0 0 / 0.05);
+        padding: 0.1em 0.35em;
+        border-radius: 4px;
+      }
+      :is(.dark) .fc code {
+        background: rgb(255 255 255 / 0.08);
+      }
+
+      .fc-form {
+        margin: 1.75rem 0 1rem;
+      }
+      .fc-label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.4rem;
+      }
+      .fc-input-row {
+        display: flex;
+        gap: 0.5rem;
+      }
+      .fc-input-row input {
+        flex: 1;
+        padding: 0.7rem 0.85rem;
+        font-size: 1rem;
+        border: 1px solid rgb(0 0 0 / 0.18);
+        border-radius: 8px;
+        background: var(--bg, #fff);
+        color: inherit;
+      }
+      :is(.dark) .fc-input-row input {
+        border-color: rgb(255 255 255 / 0.2);
+        background: rgb(255 255 255 / 0.04);
+      }
+      .fc-input-row input:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 1px;
+      }
+      #fc-submit {
+        padding: 0.7rem 1.4rem;
+        font-size: 1rem;
+        font-weight: 600;
+        color: #fff;
+        background: #2563eb;
+        border: none;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: background 0.15s ease;
+      }
+      #fc-submit:hover:not(:disabled) {
+        background: #1d4ed8;
+      }
+      #fc-submit:disabled {
+        opacity: 0.6;
+        cursor: progress;
+      }
+      .fc-hint {
+        margin: 0.5rem 0 0;
+        font-size: 0.85rem;
+        color: var(--gray, #777);
+      }
+
+      .fc-status {
+        margin: 1rem 0;
+        padding: 0.85rem 1rem;
+        border-radius: 8px;
+        font-size: 0.95rem;
+      }
+      .fc-status--loading {
+        background: rgb(37 99 235 / 0.08);
+        color: #1d4ed8;
+      }
+      .fc-status--error {
+        background: rgb(220 38 38 / 0.08);
+        color: #b91c1c;
+      }
+
+      .fc-verdict {
+        display: flex;
+        align-items: center;
+        gap: 0.85rem;
+        padding: 1rem 1.15rem;
+        border-radius: 10px;
+        margin: 1.5rem 0 1rem;
+        border: 1px solid transparent;
+      }
+      .fc-verdict p {
+        margin: 0;
+        font-weight: 500;
+      }
+      .fc-verdict--pass { background: rgb(22 163 74 / 0.08); border-color: rgb(22 163 74 / 0.25); }
+      .fc-verdict--warn { background: rgb(217 119 6 / 0.08); border-color: rgb(217 119 6 / 0.25); }
+      .fc-verdict--fail { background: rgb(220 38 38 / 0.08); border-color: rgb(220 38 38 / 0.25); }
+
+      .fc-badge {
+        flex-shrink: 0;
+        font-size: 0.8rem;
+        font-weight: 700;
+        padding: 0.25rem 0.6rem;
+        border-radius: 999px;
+        white-space: nowrap;
+      }
+      .fc-badge--pass { background: #16a34a; color: #fff; }
+      .fc-badge--warn { background: #d97706; color: #fff; }
+      .fc-badge--fail { background: #dc2626; color: #fff; }
+
+      .fc-summary {
+        font-size: 0.92rem;
+        color: var(--gray, #555);
+        margin-bottom: 1.5rem;
+      }
+      .fc-summary p { margin: 0.35rem 0; }
+      .fc-robots { font-size: 0.85rem; opacity: 0.85; }
+
+      .fc-raw {
+        margin-top: 0.75rem;
+      }
+      .fc-raw summary {
+        cursor: pointer;
+        font-weight: 600;
+      }
+      .fc-raw pre {
+        margin: 0.6rem 0 0;
+        padding: 0.85rem;
+        background: rgb(0 0 0 / 0.04);
+        border-radius: 8px;
+        overflow-x: auto;
+        font-size: 0.82rem;
+        line-height: 1.5;
+      }
+      :is(.dark) .fc-raw pre { background: rgb(255 255 255 / 0.06); }
+      .fc-raw--empty { font-style: italic; }
+
+      .fc-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 1rem;
+      }
+      .fc-card {
+        border: 1px solid rgb(0 0 0 / 0.1);
+        border-radius: 12px;
+        padding: 1rem;
+        background: var(--bg, #fff);
+      }
+      :is(.dark) .fc-card {
+        border-color: rgb(255 255 255 / 0.12);
+        background: rgb(255 255 255 / 0.03);
+      }
+      .fc-card--fail { border-left: 4px solid #dc2626; }
+      .fc-card--warn { border-left: 4px solid #d97706; }
+      .fc-card--pass { border-left: 4px solid #16a34a; }
+
+      .fc-card-head {
+        display: flex;
+        align-items: center;
+        gap: 0.85rem;
+        margin-bottom: 0.85rem;
+      }
+      .fc-preview {
+        width: 48px;
+        height: 48px;
+        flex-shrink: 0;
+        display: grid;
+        place-items: center;
+        border-radius: 8px;
+        background:
+          repeating-conic-gradient(rgb(0 0 0 / 0.06) 0% 25%, transparent 0% 50%) 50% / 14px 14px;
+        overflow: hidden;
+      }
+      .fc-preview img {
+        max-width: 100%;
+        max-height: 100%;
+        image-rendering: auto;
+      }
+      .fc-noimg {
+        font-size: 0.65rem;
+        color: #999;
+        text-align: center;
+      }
+      .fc-card-title {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        align-items: flex-start;
+      }
+      .fc-tag {
+        font-size: 0.72rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 0.15rem 0.5rem;
+        border-radius: 5px;
+      }
+      .fc-tag--link { background: rgb(37 99 235 / 0.12); color: #2563eb; }
+      .fc-tag--fallback { background: rgb(0 0 0 / 0.08); color: #555; }
+      :is(.dark) .fc-tag--fallback { background: rgb(255 255 255 / 0.1); color: #ccc; }
+
+      .fc-meta {
+        display: grid;
+        gap: 0.3rem;
+        margin: 0 0 0.75rem;
+        font-size: 0.84rem;
+      }
+      .fc-meta > div {
+        display: grid;
+        grid-template-columns: 110px 1fr;
+        gap: 0.5rem;
+      }
+      .fc-meta dt { color: var(--gray, #888); }
+      .fc-meta dd { margin: 0; word-break: break-word; }
+      .fc-meta a { color: #2563eb; }
+
+      .fc-diags {
+        list-style: none;
+        margin: 0;
+        padding: 0.75rem 0 0;
+        border-top: 1px dashed rgb(0 0 0 / 0.1);
+        display: grid;
+        gap: 0.4rem;
+      }
+      :is(.dark) .fc-diags { border-top-color: rgb(255 255 255 / 0.12); }
+      .fc-diag {
+        font-size: 0.84rem;
+        line-height: 1.4;
+        padding-left: 1.4rem;
+        position: relative;
+      }
+      .fc-diag::before {
+        position: absolute;
+        left: 0;
+        font-weight: 700;
+      }
+      .fc-diag--pass::before { content: "✓"; color: #16a34a; }
+      .fc-diag--warn::before { content: "▲"; color: #d97706; }
+      .fc-diag--fail::before { content: "✕"; color: #dc2626; }
+
+      @media (max-width: 520px) {
+        .fc-input-row { flex-direction: column; }
+        #fc-submit { width: 100%; }
+      }
+    </style>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
Adds a **Favicon Checker** at `/tools/favicon-checker` that shows your site's favicon the way Google Search sees it.

The actual check (`/api/favicon-check`) runs server-side and replicates Google's documented favicon discovery:

1. Crawls the page HTML and `/robots.txt` as **`Googlebot`**
2. Parses icon `<link>` tags (`icon`, `shortcut icon`, `apple-touch-icon`, `mask-icon`, `fluid-icon`) and resolves relative hrefs
3. Always also tests the `/favicon.ico` root fallback
4. Fetches each icon as **`Googlebot-Image/1.0`**, capturing status, redirects, content-type, byte size, and sniffed format/dimensions (PNG/ICO/GIF/JPEG/SVG/WebP)
5. Evaluates robots.txt crawlability against the `Googlebot-Image` token

The browser can't set a custom `User-Agent` or fetch cross-origin, so the lookup has to happen on the server.

## UI per result
- **Rendered preview** — base64 data URI of the exact bytes Googlebot-Image received (faithful even if a site serves bots differently)
- **HTTP details** — status, redirects, content-type, size, dimensions
- **Pass/fail diagnostics** — blocked by robots, not an image, too small (<8×8), not square, not a multiple of 48px, fetch failures
- **Raw `<link>` tags** discovered in the head

## Verification
- `npx astro check` — 0 errors
- **github.com** → ✓ Pass (4 declared icons + favicon.ico, correct sizes/formats)
- **example.com** → ▲ Warning (declared icon serves `text/plain`, `/favicon.ico` 404s)
- Empty input → HTTP 400 with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)